### PR TITLE
Adding redirect url to invitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ I am not a security researcher or expert, just a developer unsatisfied with the 
 
 ## Credits
 
+This project would not be possible without the incredible work of others including but not limited to:
+
 [node-oidc-provider](https://github.com/panva/node-oidc-provider) Handles VoidAuth OIDC Provider functionality
 
 [SimpleWebAuthn](https://github.com/MasterKale/SimpleWebAuthn) Used by VoidAuth for webauthn/passkey support

--- a/default_email_templates/invitation/html.pug
+++ b/default_email_templates/invitation/html.pug
@@ -2,8 +2,7 @@ div(style='font-family:monospace;font-weight:bold;margin:2rem;')
   h1(align='center') You Are Invited To
   h2(align='center') #{app_title}
   br
-  p(align='center')
-    | #{name}, please accept your invitation by clicking the button below:
+  p(align='center') #{name ? name+', ' : ''}please accept your invitation by clicking the button below:
   br
   div(align='center')
     a(style=`background-color:${primary_color};color:${primary_contrast_color};text-decoration:none;padding:1rem;border-radius:100px;` href=`${invitation_url}`)

--- a/default_email_templates/invitation/text.pug
+++ b/default_email_templates/invitation/text.pug
@@ -1,5 +1,5 @@
 | You Are Invited To
 | #{app_title}
-| #{name}, please accept your invitation by following the link below.
+| #{name ? name+', ' : ''}please accept your invitation by following the link below.
 | #{invitation_url}
 | You received this email because you are invited to #{app_title}.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,6 +31,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
         "ngx-spinner": "^19.0.0",
+        "psl": "^1.15.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.8.1",
         "typescript": "~5.8.3",
@@ -7394,6 +7395,27 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/psl/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "ngx-spinner": "^19.0.0",
+    "psl": "^1.15.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.8.1",
     "typescript": "~5.8.3",

--- a/frontend/src/app/pages/admin/invitations/invitation/invitation.component.html
+++ b/frontend/src/app/pages/admin/invitations/invitation/invitation.component.html
@@ -32,7 +32,7 @@
               [disabled]="form.dirty"
               (click)="sendEmail()"
             >
-              Email Invite
+              Send Invite
             </button>
           }
         </mat-card-actions>
@@ -46,6 +46,15 @@
 <mat-card class="form-card">
   <mat-card-content>
     <form [formGroup]="form" (ngSubmit)="submit()">
+      <mat-form-field>
+        <mat-label>Redirect</mat-label>
+        <input matInput type="text" formControlName="redirect" />
+        <mat-hint>Where the user will be redirected after successfully accepting the invitation.</mat-hint>
+        @if (form.controls.redirect.errors) {
+          <mat-error>{{ form.controls.redirect.errors | validationError }}</mat-error>
+        }
+      </mat-form-field>
+
       <mat-form-field>
         <mat-label>Username</mat-label>
         <input matInput type="text" formControlName="username" />

--- a/frontend/src/app/pages/admin/invitations/invitation/invitation.component.ts
+++ b/frontend/src/app/pages/admin/invitations/invitation/invitation.component.ts
@@ -14,6 +14,8 @@ import type { InvitationDetails } from '@shared/api-response/InvitationDetails'
 import { ConfigService } from '../../../../services/config.service'
 import type { ConfigResponse } from '@shared/api-response/ConfigResponse'
 import { SpinnerService } from '../../../../services/spinner.service'
+import { isValidURL } from '../../../../validators/validators'
+import * as psl from 'psl'
 
 @Component({
   selector: 'app-invitation',
@@ -54,6 +56,7 @@ export class InvitationComponent {
       value: null,
       disabled: false,
     }, [Validators.minLength(4)]),
+    redirect: new FormControl<string | null>(null, [isValidURL]),
     emailVerified: new FormControl<boolean>(true),
     groups: new FormControl<string[]>({
       value: [],
@@ -110,7 +113,8 @@ export class InvitationComponent {
       name: invitation.name ?? null,
       email: invitation.email ?? null,
       groups: invitation.groups,
-      emailVerified: true,
+      emailVerified: invitation.emailVerified ?? true,
+      redirect: invitation.redirect ?? psl.get(this.config?.domain || '') ?? null,
     })
     this.inviteEmail = invitation.email
     if (!this.config) {

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -8,8 +8,6 @@
 
     <link rel="icon" href="/favicon.svg" />
 
-    <link rel="apple-touch-icon" href="logo.svg" />
-
     <link rel="stylesheet" href="material-icons.css" />
     <link rel="stylesheet" href="generated-mat-theme.css" />
     <link rel="stylesheet" href="custom.css" />

--- a/migrations/20250705155034_invitation_redirect.ts
+++ b/migrations/20250705155034_invitation_redirect.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('invitation', (table) => {
+    table.text('redirect')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('invitation', (table) => {
+    table.dropColumn('redirect')
+  })
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -149,16 +149,6 @@ function modifyIndex() {
     }
   }
 
-  if (!brandingFiles.includes('logo.svg')) {
-    if (brandingFiles.includes('logo.png')) {
-      index = index.replaceAll('logo.svg', 'logo.png')
-    } else if (brandingFiles.includes('favicon.svg')) {
-      index = index.replaceAll('logo.svg', 'favicon.svg')
-    } else if (brandingFiles.includes('favicon.png')) {
-      index = index.replaceAll('logo.svg', 'favicon.png')
-    }
-  }
-
   return index
 }
 

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -612,6 +612,24 @@ adminRouter.post('/invitation',
       },
       ...emailValidation,
     },
+    redirect: {
+      default: {
+        options: null,
+      },
+      optional: {
+        options: {
+          values: 'null',
+        },
+      },
+      ...stringValidation,
+      isURL: {
+        options: {
+          protocols: ['http', 'https'],
+          require_tld: false,
+          require_protocol: true,
+        },
+      },
+    },
     groups: {
       isArray: true,
     },

--- a/shared/api-request/admin/InvitationUpsert.ts
+++ b/shared/api-request/admin/InvitationUpsert.ts
@@ -1,4 +1,4 @@
 import type { InvitationDetails } from '@shared/api-response/InvitationDetails'
 
 export type InvitationUpsert = Partial<Pick<InvitationDetails, 'id'>>
-  & Pick<InvitationDetails, 'username' | 'email' | 'name' | 'groups' | 'emailVerified'>
+  & Pick<InvitationDetails, 'username' | 'email' | 'name' | 'redirect' | 'groups' | 'emailVerified'>

--- a/shared/db/Invitation.ts
+++ b/shared/db/Invitation.ts
@@ -6,6 +6,7 @@ export type Invitation = Audit & {
   username?: string | null
   email?: string | null
   name?: string | null
+  redirect?: string | null
   emailVerified?: boolean
   expiresAt: Date
 }


### PR DESCRIPTION
## Description
Adding redirect url to invitations, defaults to oidc domain root.
Fixing bug where invites without groups would fail. Removing apple touch icon.
Fixing issue in invitation email where if name was missing, the grammar was wrong.
