### PR TITLE
Added confirmation dialog for some admin actions

### DIFF
--- a/frontend/src/app/components/copy-field/copy-field.component.html
+++ b/frontend/src/app/components/copy-field/copy-field.component.html
@@ -9,7 +9,7 @@
       matSuffix
       [matTooltip]="label() + ' Endpoint'"
       [cdkCopyToClipboard]="val"
-      (click)="snackbarService.show(label() + ' copied to clipboard.')"
+      (click)="snackbarService.message(label() + ' copied to clipboard.')"
     >
       <mat-icon fontSet="material-icons-round" matSuffix>copy</mat-icon>
     </button>

--- a/frontend/src/app/dialogs/confirm/confirm.component.html
+++ b/frontend/src/app/dialogs/confirm/confirm.component.html
@@ -1,0 +1,8 @@
+@if (data.header) {
+  <h2 mat-dialog-title>{{ data.header }}</h2>
+}
+<mat-dialog-content>{{ data.message }}</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button matButton mat-dialog-close>Cancel</button>
+  <button matButton [mat-dialog-close]="true" cdkFocusInitial>Confirm</button>
+</mat-dialog-actions>

--- a/frontend/src/app/dialogs/confirm/confirm.component.ts
+++ b/frontend/src/app/dialogs/confirm/confirm.component.ts
@@ -1,0 +1,16 @@
+import { Component, inject } from '@angular/core'
+import { MaterialModule } from '../../material-module'
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog'
+
+@Component({
+  selector: 'app-confirm',
+  imports: [
+    MaterialModule,
+  ],
+  templateUrl: './confirm.component.html',
+  styleUrl: './confirm.component.scss',
+})
+export class ConfirmComponent {
+  readonly dialogRef = inject(MatDialogRef<ConfirmComponent>)
+  readonly data = inject<{ message: string, header?: string }>(MAT_DIALOG_DATA)
+}

--- a/frontend/src/app/material-module.ts
+++ b/frontend/src/app/material-module.ts
@@ -20,6 +20,7 @@ import { MatTooltipModule } from '@angular/material/tooltip'
 import { ClipboardModule } from '@angular/cdk/clipboard'
 import { MatProgressBarModule } from '@angular/material/progress-bar'
 import { MatExpansionModule } from '@angular/material/expansion'
+import { MatDialogModule } from '@angular/material/dialog'
 import { NgxSpinnerModule } from 'ngx-spinner'
 
 @NgModule({
@@ -46,6 +47,7 @@ import { NgxSpinnerModule } from 'ngx-spinner'
     MatTooltipModule,
     MatProgressBarModule,
     MatExpansionModule,
+    MatDialogModule,
   ],
   providers: [
     { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } },

--- a/frontend/src/app/pages/admin/clients/upsert-client/upsert-client.component.html
+++ b/frontend/src/app/pages/admin/clients/upsert-client/upsert-client.component.html
@@ -35,7 +35,7 @@
           matTooltip="Copy Secret"
           [disabled]="!secret.value"
           [cdkCopyToClipboard]="secret.value || ''"
-          (click)="snackbarService.show('Secret copied to clipboard.')"
+          (click)="snackbarService.message('Secret copied to clipboard.')"
         >
           <mat-icon fontSet="material-icons-round" matSuffix>copy</mat-icon>
         </button>

--- a/frontend/src/app/pages/admin/invitations/invitation/invitation.component.html
+++ b/frontend/src/app/pages/admin/invitations/invitation/invitation.component.html
@@ -13,7 +13,7 @@
             matSuffix
             matTooltip="Copy Invite Link"
             [cdkCopyToClipboard]="inviteLink || ''"
-            (click)="snackbarService.show('Invite link copied to clipboard.')"
+            (click)="snackbarService.message('Invite link copied to clipboard.')"
           >
             <mat-icon fontSet="material-icons-round" matSuffix>copy</mat-icon>
           </button>

--- a/frontend/src/app/pages/admin/password-resets/password-resets.component.html
+++ b/frontend/src/app/pages/admin/password-resets/password-resets.component.html
@@ -66,7 +66,7 @@
             matSuffix
             matTooltip="Copy Link"
             [cdkCopyToClipboard]="adminService.getPasswordResetLink(domain, row.id, row.challenge)"
-            (click)="snackbarService.show('Reset link copied to clipboard.')"
+            (click)="snackbarService.message('Reset link copied to clipboard.')"
           >
             <mat-icon fontSet="material-icons-round" matSuffix>copy</mat-icon>
           </button>

--- a/frontend/src/app/pages/forgot-password/forgot-password.component.ts
+++ b/frontend/src/app/pages/forgot-password/forgot-password.component.ts
@@ -49,7 +49,7 @@ export class ForgotPasswordComponent implements OnInit {
       const result = await this.authService.sendPasswordReset(input)
       this.emailSent = result.emailSent
 
-      this.snackbarService.show(this.emailSent ? 'Password reset link sent.' : 'Password reset link created, but could not be sent.')
+      this.snackbarService.message(this.emailSent ? 'Password reset link sent.' : 'Password reset link created, but could not be sent.')
     } catch (e) {
       let shownError: string | null = null
 

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -128,7 +128,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       await this.userService.updateProfile({
         name: this.profileForm.value.name ?? undefined,
       })
-      this.snackbarService.show('Profile updated.')
+      this.snackbarService.message('Profile updated.')
     } catch (_e) {
       this.snackbarService.error('Could not update profile.')
     } finally {
@@ -149,7 +149,7 @@ export class HomeComponent implements OnInit, OnDestroy {
         oldPassword: oldPassword,
         newPassword: newPassword,
       })
-      this.snackbarService.show('Password updated.')
+      this.snackbarService.message('Password updated.')
       await this.loadUser()
     } catch (_e) {
       this.snackbarService.error('Could not update password.')
@@ -170,9 +170,9 @@ export class HomeComponent implements OnInit, OnDestroy {
       })
       // if email verification enabled, indicate that in message
       if ((await this.configService.getConfig()).emailVerification) {
-        this.snackbarService.show('Verification email sent.')
+        this.snackbarService.message('Verification email sent.')
       } else {
-        this.snackbarService.show('Email updated.')
+        this.snackbarService.message('Email updated.')
       }
     } catch (_e) {
       this.snackbarService.error('Could not update email.')

--- a/frontend/src/app/pages/reset-password/reset-password.component.ts
+++ b/frontend/src/app/pages/reset-password/reset-password.component.ts
@@ -78,7 +78,7 @@ export class ResetPasswordComponent {
         challenge: this.challenge,
         newPassword: this.passwordForm.controls.newPassword.value,
       })
-      this.snackbarService.show('Password Reset Complete.')
+      this.snackbarService.message('Password Reset Complete.')
       await this.router.navigate([REDIRECT_PATHS.LOGIN])
     } catch (e) {
       console.error(e)

--- a/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.ts
+++ b/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.ts
@@ -48,7 +48,7 @@ export class VerifySentComponent implements OnInit {
         },
         queryParamsHandling: 'merge',
       })
-      this.snackbarService.show('Verification Email Re-Sent.')
+      this.snackbarService.message('Verification Email Re-Sent.')
     } catch (e) {
       console.error(e)
       let error: string | null = null

--- a/frontend/src/app/services/snackbar.service.ts
+++ b/frontend/src/app/services/snackbar.service.ts
@@ -8,9 +8,9 @@ export class SnackbarService {
   private snackBar = inject(MatSnackBar)
 
   private messageDuration = 6
-  private errorDuration = 30
+  private errorDuration = 15
 
-  show(message: string) {
+  message(message: string) {
     this.snackBar.open(message, 'Ok', {
       duration: this.messageDuration * 1000,
     })

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -35,10 +35,10 @@ router.use(async (req, res, next) => {
   if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method.toUpperCase())) {
     await transaction()
     res.on('finish', async () => {
-      if (res.statusCode >= 200 && res.statusCode < 300) {
-        await commit()
-      } else {
+      if (res.statusCode >= 500 && res.statusCode < 600) {
         await rollback()
+      } else {
+        await commit()
       }
     })
   }


### PR DESCRIPTION


## Description
Added confirmation dialog, show for any delete from admin tables and pages, and admin bulk actions.

Fixed automatic transaction rollback to only for 5xx status codes.


## Related Tickets & Documents
#56

## Screenshots

<!-- Any visual changes require screenshots -->
<img width="1514" height="978" alt="image" src="https://github.com/user-attachments/assets/b331f348-2ff5-4f86-9554-67eca769ab89" />

