### PR TITLE
Admin Password Reset Page Link Copy Fix

### DIFF
--- a/frontend/src/app/pages/admin/password-resets/password-resets.component.html
+++ b/frontend/src/app/pages/admin/password-resets/password-resets.component.html
@@ -65,7 +65,7 @@
             mat-icon-button
             matSuffix
             matTooltip="Copy Link"
-            [cdkCopyToClipboard]="adminService.getPasswordResetLink(domain, row.id, row.challenge)"
+            [cdkCopyToClipboard]="adminService.getPasswordResetLink(domain, row.userId, row.challenge)"
             (click)="snackbarService.message('Reset link copied to clipboard.')"
           >
             <mat-icon fontSet="material-icons-round" matSuffix>copy</mat-icon>


### PR DESCRIPTION
## Description
Fix link copy in admin Password Resets page not copying the correct link.
