### PR TITLE
Passkey Prompt Fixes

### DIFF
--- a/frontend/src/app/pages/registration/registration.component.ts
+++ b/frontend/src/app/pages/registration/registration.component.ts
@@ -135,10 +135,7 @@ export class RegistrationComponent implements OnInit {
       })
 
       // See if we want to ask the user to register a passkey
-      if (redirect.success
-        && this.passkeySupport?.enabled
-        && !this.passkeyService.localPasskeySeen()
-        && !this.passkeyService.localPasskeySkipped()) {
+      if (redirect.success && this.passkeySupport?.enabled) {
         try {
           this.spinnerService.hide()
           await this.passkeyService.dialogRegistration()

--- a/frontend/src/app/services/passkey.service.ts
+++ b/frontend/src/app/services/passkey.service.ts
@@ -101,11 +101,6 @@ export class PasskeyService {
 
   async dialogRegistration() {
     return new Promise<void>((resolve, _reject) => {
-      void this.register().then(() => {
-        // If success without dialog, resolve
-        resolve()
-      }).catch((_ee: unknown) => { })
-
       const dialog = this.dialog.open(PasskeyDialog, { disableClose: true })
 
       dialog.afterClosed().subscribe((result) => {
@@ -146,7 +141,7 @@ export type PasskeySupport = {
     MaterialModule,
   ],
   template: `
-    <h1 mat-dialog-title>{{ passkeySupport?.platformName ? "Enable " + passkeySupport?.platformName : "Register Passkey" }}</h1>
+    <h1 mat-dialog-title>{{ passkeySupport?.platformName ? "Enable " + passkeySupport?.platformName + "?" : "Register Passkey?" }}</h1>
     <mat-dialog-content style="height: 200px; display: flex; justify-content: center; align-items: center;">
       <mat-icon align="center" style="width: 100px; height: 100px; font-size: 100px;" fontSet="material-icons-round" matSuffix>{{ passkeySupport?.platformIcon ?? "key" }}</mat-icon>
     </mat-dialog-content>


### PR DESCRIPTION
## Description
Password based user sign ups should not care about previously seen passkey when deciding whether to prompt the user to create one.
Stop attempting automatic passkey registration at the same time as prompting the user to do it.
