### PR TITLE
Fix EMAIL_VERIFICATION Not Causing Email to be Required During Registration

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -64,17 +64,17 @@ VoidAuth is configurable primarily by environment variable. The available enviro
 | Name | Default | Description | Required | Recommended |
 | :------ | :-- | :-------- | :--- | :--- |
 | APP_URL | | URL VoidAuth will be served on. Must start with`https://`, subdirectory routing is supported. ex. `https://auth.example.com` or `https://example.com/auth` | 🔴 | |
-| DEFAULT_REDIRECT | ${APP_URL} | The home/landing/app url for your domain. This is where users will be redirected upon accepting an invitation, logout, or clicking the logo when already on the auth home page. | | ✅ |
-| SIGNUP | false | Whether the app allows new users to self-register themselves without invitation. | | |
-| SIGNUP_REQUIRES_APPROVAL | true | Whether new users who register themselves require approval by an admin. Setting this to **false** while **SIGNUP** is **true** enables open self-registration; use with caution! | | |
-| EMAIL_VERIFICATION | false | If true, users must have an email address and will get a verification email when changing their email address before it can be used. If you are using an email provider, this should be set to true. | | ✅ (If SMTP Settings are set) |
+| DEFAULT_REDIRECT | `${APP_URL}` | The home/landing/app url for your domain. This is where users will be redirected upon accepting an invitation, logout, or clicking the logo when already on the auth home page. | | ✅ |
+| SIGNUP | `false` | Whether the app allows new users to self-register themselves without invitation. | | |
+| SIGNUP_REQUIRES_APPROVAL | `true` | Whether new users who register themselves require approval by an admin. Setting this to **false** while **SIGNUP** is **true** enables open self-registration; use with caution! | | |
+| EMAIL_VERIFICATION | `true` if SMTP_HOST is set, otherwise `false` | If true, users must have an email address and will get a verification email when changing their email address before it can be used. If you are using an email provider, this should be set to true. | | |
 
 #### App Customization
 | Name | Default | Description | Required | Recommended |
 | :------ | :-- | :-------- | :--- | :--- |
-| APP_TITLE | VoidAuth | Title that will show on the web interface, use your own brand/app/title. | | ✅ |
-| APP_PORT | 3000 | The port that app will listen on. | | |
-| APP_COLOR | #906bc7 | Theme color, rgb format; ex. #xxyyzz | | ✅ |
+| APP_TITLE | `VoidAuth` | Title that will show on the web interface, use your own brand/app/title. | | ✅ |
+| APP_PORT | `3000` | The port that app will listen on. | | |
+| APP_COLOR | `#906bc7` | Theme color, rgb format; ex. #xxyyzz | | ✅ |
 | CONTACT_EMAIL | | The email address used for 'Contact' links, which are shown on most end-user pages if this is set. | | |
 
 #### DB Settings
@@ -82,9 +82,9 @@ VoidAuth is configurable primarily by environment variable. The available enviro
 | :------ | :-- | :-------- | :--- | :--- |
 | DB_HOST | | Host address of the database. | 🔴 | |
 | DB_PASSWORD | | Password of the database. If you do not enter one VoidAuth will recommend one to you. | 🔴 | |
-| DB_PORT | 5432 | Port of the database. | | |
-| DB_USER | postgres | Username used to sign into the database by the app. | | |
-| DB_NAME | postgres | Database name used to connect to the database by the app. | | |
+| DB_PORT | `5432` | Port of the database. | | |
+| DB_USER | `postgres` | Username used to sign into the database by the app. | | |
+| DB_NAME | `postgres` | Database name used to connect to the database by the app. | | |
 | STORAGE_KEY | | Storage encryption key for secret values such as keys and client secrets. Must be at least 32 characters long and should be randomly generated. If you do not enter one VoidAuth will recommend one to you. | 🔴 | |
 | STORAGE_KEY_SECONDARY | | Secondary storage encryption key, used when rotating the primary storage encryption key. | | |
 
@@ -96,16 +96,16 @@ All of these settings are ✅ recommended to be set to the correct values for yo
 | :------ | :-- | :-------- |
 | SMTP_HOST | | SMTP Host; ex. `mail.example.com` |
 | SMTP_FROM | | SMTP From field; ex.`My App<app@example.com>` |
-| SMTP_PORT | 587 | SMTP port to use. |
-| SMTP_SECURE | false | SMTP has TLS/SSL enabled. |
+| SMTP_PORT | `587` | SMTP port to use. |
+| SMTP_SECURE | `false` | SMTP has TLS/SSL enabled. |
 | SMTP_USER | | SMTP username used to sign into email provider; ex `user@example.com` |
 | SMTP_PASS | | SMTP password used to sign into email provider |
 
 #### Misc.
 | Name | Default | Description | Required | Recommended |
 | :------ | :-- | :-------- | :--- | :--- |
-| PASSWORD_STRENGTH | 3 | The minimum strength of users passwords, at least 3 is recommended. Must be between 0 - 4. | | |
-| ADMIN_EMAILS | hourly | The minimum duration between admin notification emails. Can be set to values like: '4 hours', '30 minutes', 'weekly', 'daily', etc. If set to 'false', admin notification emails are disabled. | | | 
+| PASSWORD_STRENGTH | `3` | The minimum strength of users passwords, at least 3 is recommended. Must be between 0 - 4. | | |
+| ADMIN_EMAILS | `hourly` | The minimum duration between admin notification emails. Can be set to values like: '4 hours', '30 minutes', 'weekly', 'daily', etc. If set to 'false', admin notification emails are disabled. | | | 
 
 > [!IMPORTANT]
 > Some configuration options only make sense when used together. **EMAIL_VERIFICATION** should only be set if the **SMTP_** options are also set. Likewise, **SIGNUP_REQUIRES_APPROVAL** does nothing unless **SIGNUP** is set.

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -2,6 +2,7 @@ import { type ApplicationConfig, provideZoneChangeDetection } from '@angular/cor
 import { provideRouter } from '@angular/router'
 import { routes } from './app.routes'
 import { provideHttpClient, withInterceptors, type HttpInterceptorFn } from '@angular/common/http'
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async'
 import { getBaseHrefPath } from './services/config.service'
 
 const baseHrefInterceptor: HttpInterceptorFn = (req, next) => {
@@ -26,5 +27,7 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(
       withInterceptors([baseHrefInterceptor]),
     ),
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    provideAnimationsAsync(),
   ],
 }

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -15,7 +15,7 @@ export const routes: Routes = [
 
   { path: REDIRECT_PATHS.RESET_PASSWORD, loadComponent: () => import('./pages/reset-password/reset-password.component').then(m => m.ResetPasswordComponent) },
 
-  { path: `${REDIRECT_PATHS.LOGOUT}/:challenge`, loadComponent: () => import('./pages/logout/logout.component').then(m => m.LogoutComponent), canActivate: [loggedInGuard] },
+  { path: `${REDIRECT_PATHS.LOGOUT}/:challenge`, loadComponent: () => import('./pages/logout/logout.component').then(m => m.LogoutComponent) },
 
   { path: `${REDIRECT_PATHS.VERIFY_EMAIL}/:id/:challenge`, loadComponent: () => import('./pages/verify-email/verify/verify.component').then(m => m.VerifyComponent) },
 

--- a/frontend/src/app/pages/admin/clients/upsert-client/upsert-client.component.html
+++ b/frontend/src/app/pages/admin/clients/upsert-client/upsert-client.component.html
@@ -34,7 +34,7 @@
           }
         </mat-form-field>
 
-        <div mat-subheader>Security Groups:</div>
+        <div mat-subheader>Allowed Groups:</div>
         @for (g of form.value.groups; track g) {
           <mat-list-item>
             <mat-icon fontSet="material-icons-round" matListItemIcon class="clickable" (click)="removeGroup(g)">cancel</mat-icon>

--- a/frontend/src/app/pages/admin/domains/domain/domain.component.html
+++ b/frontend/src/app/pages/admin/domains/domain/domain.component.html
@@ -44,7 +44,7 @@
           }
         </mat-form-field>
 
-        <div mat-subheader>Security Groups:</div>
+        <div mat-subheader>Allowed Groups:</div>
         @for (g of form.value.groups; track g) {
           <mat-list-item>
             <mat-icon fontSet="material-icons-round" matListItemIcon class="clickable" (click)="removeGroup(g)">cancel</mat-icon>

--- a/frontend/src/app/pages/home/home.component.ts
+++ b/frontend/src/app/pages/home/home.component.ts
@@ -117,6 +117,7 @@ export class HomeComponent implements OnInit, OnDestroy {
 
       if (this.user.hasPassword) {
         this.passwordForm.controls.oldPassword.addValidators(Validators.required)
+        this.passwordForm.controls.oldPassword.updateValueAndValidity()
       }
     } finally {
       this.spinnerService.hide()

--- a/frontend/src/app/pages/registration/registration.component.ts
+++ b/frontend/src/app/pages/registration/registration.component.ts
@@ -79,6 +79,7 @@ export class RegistrationComponent implements OnInit {
         this.passkeySupport = await this.passkeyService.getPasskeySupport()
         if (!this.passkeySupport.enabled) {
           this.form.controls.password.addValidators(Validators.required)
+          this.form.controls.password.updateValueAndValidity()
         }
       } catch (_e) {
         // interaction session is missing, could not log in without it
@@ -123,6 +124,7 @@ export class RegistrationComponent implements OnInit {
           this.spinnerService.show()
           if (this.config.emailVerification) {
             this.form.controls.email.addValidators(Validators.required)
+            this.form.controls.email.updateValueAndValidity()
           }
         } finally {
           this.spinnerService.hide()

--- a/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.html
+++ b/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.html
@@ -1,13 +1,14 @@
-<h1>{{ sent ? "Verification Email Sent" : "Email Verification Required" }}</h1>
 <mat-card class="form-card">
+  <mat-card-header>
+    <mat-card-title> {{ sent ? "Verification Email Sent" : "Email Verification Required" }} </mat-card-title>
+  </mat-card-header>
   <mat-card-content>
+    <mat-icon align="center" style="width: 100px; height: 100px; font-size: 100px" fontSet="material-icons-round" matSuffix>mail</mat-icon>
     <mat-card-actions>
+      <a mat-button [href]="host + '/oidc/session/end'">Logout</a>
       <button mat-button (click)="sendVerification()">
         {{ sent ? "Send Again" : "Send Verification Email" }}
       </button>
-      @if (sent) {
-        <a mat-flat-button routerLink="/">Login</a>
-      }
     </mat-card-actions>
   </mat-card-content>
 </mat-card>

--- a/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.html
+++ b/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.html
@@ -6,8 +6,8 @@
     <mat-icon align="center" style="width: 100px; height: 100px; font-size: 100px" fontSet="material-icons-round" matSuffix>mail</mat-icon>
     <mat-card-actions>
       <a mat-button [href]="host + '/oidc/session/end'">Logout</a>
-      <button mat-button (click)="sendVerification()">
-        {{ sent ? "Send Again" : "Send Verification Email" }}
+      <button mat-flat-button (click)="sendVerification()">
+        {{ sent ? "Send Again" : "Send Verification" }}
       </button>
     </mat-card-actions>
   </mat-card-content>

--- a/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.scss
+++ b/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.scss
@@ -1,5 +1,5 @@
 mat-card {
-  max-width: 600px;
+  max-width: 500px;
 }
 
 mat-card-content {
@@ -11,7 +11,7 @@ mat-card-content {
     justify-content: end;
 
     > * {
-      margin-left: 8px;
+      margin-left: 16px;
     }
   }
 }

--- a/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.scss
+++ b/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.scss
@@ -1,0 +1,17 @@
+mat-card {
+  max-width: 600px;
+}
+
+mat-card-content {
+  padding-top: 32px;
+
+  mat-card-actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+
+    > * {
+      margin-left: 8px;
+    }
+  }
+}

--- a/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.ts
+++ b/frontend/src/app/pages/verify-email/verify-sent/verify-sent.component.ts
@@ -1,18 +1,17 @@
 import { Component, inject, type OnInit } from '@angular/core'
-import { ActivatedRoute, Router, RouterLink } from '@angular/router'
+import { ActivatedRoute, Router } from '@angular/router'
 import { MaterialModule } from '../../../material-module'
 import { AuthService } from '../../../services/auth.service'
 import { HttpErrorResponse } from '@angular/common/http'
 import { SnackbarService } from '../../../services/snackbar.service'
 import { SpinnerService } from '../../../services/spinner.service'
 import type { ConfigResponse } from '@shared/api-response/ConfigResponse'
-import { ConfigService } from '../../../services/config.service'
+import { ConfigService, getCurrentHost } from '../../../services/config.service'
 
 @Component({
   selector: 'app-verify-sent',
   imports: [
     MaterialModule,
-    RouterLink,
   ],
   templateUrl: './verify-sent.component.html',
   styleUrl: './verify-sent.component.scss',
@@ -21,6 +20,7 @@ export class VerifySentComponent implements OnInit {
   sent: boolean = false
   userId: string | null = null
   config?: ConfigResponse
+  host = getCurrentHost()
 
   private router = inject(Router)
   private activatedRoute = inject(ActivatedRoute)

--- a/server/oidc/provider.ts
+++ b/server/oidc/provider.ts
@@ -1,5 +1,5 @@
 import Provider, { type Configuration } from 'oidc-provider'
-import { findAccount, getUserById } from '../db/user'
+import { findAccount, getUserById, isUnapproved, isUnverified } from '../db/user'
 import appConfig, { appUrl, basePath } from '../util/config'
 import { KnexAdapter } from './adapter'
 import type { OIDCExtraParams } from '@shared/oidc'
@@ -12,11 +12,54 @@ import * as psl from 'psl'
 import { createExpiration } from '../db/util'
 import { interactionPolicy } from 'oidc-provider'
 import { getClient } from '../db/client'
+import type { UserDetails } from '@shared/api-response/UserDetails'
 
 // Modify consent interaction policy to check for user and client groups
+let userCheckCache: Record<string, Promise<UserDetails | undefined>> = {}
+let userCheckCacheExpires: number = 0
+const getUserWithCache = async (accountId: string) => {
+  if (userCheckCacheExpires < new Date().getTime()) {
+    userCheckCache = {}
+    userCheckCacheExpires = new Date().getTime() + 30000 // 30 seconds
+  }
+  if (!userCheckCache[accountId]) {
+    userCheckCache[accountId] = getUserById(accountId)
+  }
+  return userCheckCache[accountId]
+}
 const { Check, base } = interactionPolicy
-const basePolicy = base()
-const consentPromptPolicy = basePolicy.get('consent') as interactionPolicy.Prompt
+const modifiedInteractionPolicy = base()
+const loginPromptPolicy = modifiedInteractionPolicy.get('login') as interactionPolicy.Prompt
+loginPromptPolicy.checks.add(new Check('user_not_approved',
+  'user has not been approved to login',
+  'user_not_approved', async (ctx) => {
+    const { oidc } = ctx
+    if (oidc.account?.accountId) {
+      // using a short cache
+      const user = await getUserWithCache(oidc.account.accountId)
+      if (user && isUnapproved(user)) {
+        return Check.REQUEST_PROMPT
+      }
+    }
+
+    return Check.NO_NEED_TO_PROMPT
+  },
+))
+loginPromptPolicy.checks.add(new Check('user_email_not_validated',
+  'user email address does not exist or is not validated',
+  'user_email_not_validated', async (ctx) => {
+    const { oidc } = ctx
+    if (oidc.account?.accountId && appConfig.EMAIL_VERIFICATION) {
+      const user = await getUserWithCache(oidc.account.accountId)
+      if (user && isUnverified(user)) {
+        return Check.REQUEST_PROMPT
+      }
+    }
+
+    return Check.NO_NEED_TO_PROMPT
+  },
+))
+const consentPromptPolicy = modifiedInteractionPolicy.get('consent') as interactionPolicy.Prompt
 consentPromptPolicy.checks.add(new Check('user_group_missing',
   'missing any security group that would give access to the resource',
   'user_group_missing', async (ctx) => {
@@ -98,7 +141,7 @@ const configuration: Configuration = {
     url: (_ctx, _interaction) => {
       return `${basePath()}/api/interaction`
     },
-    policy: basePolicy,
+    policy: modifiedInteractionPolicy,
   },
   ttl: {
     Session: TTLs.SESSION,

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -30,7 +30,7 @@ publicRouter.get('/config', (_req, res) => {
     appName: appConfig.APP_TITLE,
     zxcvbnMin: appConfig.PASSWORD_STRENGTH,
     emailActive: SMTP_VERIFIED,
-    emailVerification: appConfig.EMAIL_VERIFICATION,
+    emailVerification: !!appConfig.EMAIL_VERIFICATION,
     registration: appConfig.SIGNUP,
     contactEmail: appConfig.CONTACT_EMAIL,
     defaultRedirect: appConfig.DEFAULT_REDIRECT,

--- a/server/util/config.ts
+++ b/server/util/config.ts
@@ -12,7 +12,7 @@ class Config {
 
   SIGNUP = false
   SIGNUP_REQUIRES_APPROVAL = true
-  EMAIL_VERIFICATION = false
+  EMAIL_VERIFICATION: boolean | null = null
 
   APP_COLOR = '#906bc7'
 
@@ -59,9 +59,12 @@ function assignConfigValue(key: keyof Config, value: unknown) {
 
     // booleans
     case 'SMTP_SECURE':
-    case 'EMAIL_VERIFICATION':
     case 'SIGNUP':
     case 'SIGNUP_REQUIRES_APPROVAL':
+      appConfig[key] = booleanString(value) ?? appConfig[key]
+      break
+
+    case 'EMAIL_VERIFICATION':
       appConfig[key] = booleanString(value) ?? appConfig[key]
       break
 
@@ -176,6 +179,10 @@ configKeys.forEach((key: keyof Config) => {
   assignConfigValue(key, process.env[key])
 })
 
+/**
+ * Validations and Coercions
+ */
+
 // check APP_URL is set
 if (!appConfig.APP_URL || !URL.parse(appConfig.APP_URL)) {
   console.error('APP_URL must be set and be a valid URL, starting with http(s)://')
@@ -206,6 +213,15 @@ if (appConfig.PASSWORD_STRENGTH < 0 || appConfig.PASSWORD_STRENGTH > 4) {
   exit(1)
 }
 
+// If EMAIL_VALIDATION is unset, give it a default value
+if (appConfig.EMAIL_VERIFICATION == null) {
+  appConfig.EMAIL_VERIFICATION = !!appConfig.SMTP_HOST
+}
+
+//
+// Exported Utility Functions
+//
+
 export function appUrl(): URL {
   return URL.parse(appConfig.APP_URL) as URL
 }
@@ -213,5 +229,9 @@ export function appUrl(): URL {
 export function basePath() {
   return appUrl().pathname.replace(/\/$/, '')
 }
+
+//
+// Default Export
+//
 
 export default appConfig


### PR DESCRIPTION
## Description
Fixing issue where invited user did not have to enter an email even though EMAIL_VERIFICATION was true.

Set EMAIL_VERIFICATION true by default if SMTP_HOST is set. Moving unapproved/unvalidated checks to oidc provider interaction policy. 

Improved styling on email-verification-sent page.

## Screenshots

<img width="500" src="https://github.com/user-attachments/assets/e69a1b79-b2d6-4d08-a465-4a4200b905ca" />
