### PR TITLE
Fixing Special Characters in 'Name' Fields

### DIFF
--- a/server/util/validators.ts
+++ b/server/util/validators.ts
@@ -75,7 +75,12 @@ export const nameValidation = {
   optional: true,
   ...unlessNull,
   ...stringValidation,
-  matches: { options: /^[\w\s]{4,64}$/ },
+  isLength: {
+    options: {
+      min: 4,
+      max: 64,
+    },
+  },
 } as const
 
 export const newPasswordValidation = {


### PR DESCRIPTION
## Description

Fixes issue where special characters in the 'Name' field were not allowed when they should be.

## Related Tickets & Documents

#138 

## Screenshots

<img width="800" alt="screenshot showing unicode name in an invitation" src="https://github.com/user-attachments/assets/0ab29a08-321b-4b33-abed-b1734e1ffab6" />

