### PR TITLE
OIDC Claim 'emailVerified' Should Always be a Boolean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ COPY ./shared ./shared
 COPY --from=build /app/frontend/dist ./frontend/dist
 
 VOLUME ["/app/config"]
+VOLUME ["/app/db"]
 EXPOSE 3000
 ENTRYPOINT [ "npx", "tsx", "server/index.ts" ]
 

--- a/server/db/user.ts
+++ b/server/db/user.ts
@@ -105,8 +105,8 @@ export async function findAccount(_: KoaContextWithOIDC | null, id: string): Pro
       const accountClaims: AccountClaims & Partial<UserDetails> = { sub: id }
 
       if (scope.includes('email')) {
-        accountClaims.email = user.email
-        accountClaims.email_verified = user.emailVerified
+        accountClaims.email = user.email ?? null
+        accountClaims.email_verified = !!user.emailVerified
       }
 
       if (scope.includes('profile')) {


### PR DESCRIPTION
## Description
Should fix issue with some OIDC Clients that will not accept 0-1. Add back Dockerfile /app/db volume, to make finding sqlite db easier if a volume was not mounted.

## Related Tickets & Documents
#153
