### PR TITLE
Native OIDC Clients Allow Non-Reversed Domain Schemes

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -71,18 +71,15 @@ export async function serve() {
 
   // Check inconsistencies that cause node-oidc-provider to throw errors
   // And provide more clear errors instead
-  function checkAPPUrl(req: Request, res: Response, next: NextFunction) {
+  function checkAPPUrl(req: Request, _res: Response, next: NextFunction) {
     // If base hostname does not match, OIDC authorization endpoint will fail to set cookie that can persist
+    // Do not throw a hard error here, hostname might be getting mangled on the way in but still correct in browser
     if (psl.get(req.hostname) !== psl.get(appUrl().hostname)) {
       const message = 'Invalid request hostname ' + req.hostname + ', '
         + '$APP_URL hostname is ' + appUrl().hostname + ' . '
         + 'If ' + req.hostname + ' does not match what is displayed in the browser URL bar '
         + 'this may indicate a reverse-proxy misconfiguration.'
       logger.debug(message)
-      res.status(400).send({
-        message,
-      })
-      return
     }
 
     next()


### PR DESCRIPTION
## Description
Allow native OIDC clients that do not use reverse domain schemes. No guarantee that this will work, needs testing.
Do not throw hard error when request hostname would not allow session cookie to be set, it might just be getting mangled on the way in. Send to debug instead.

## Related Tickets & Documents
#198 

