### PR TITLE
Fix Incorrect Protocol Matching for Wildcard Redirects

### DIFF
--- a/shared/utils.ts
+++ b/shared/utils.ts
@@ -21,7 +21,7 @@ type URLPatternGroups = {
 export function urlFromWildcardHref(input: string) {
   const pattern = new RegExp(
     '^'
-    + '(?:(?<protocol>[^:/?#.]+:)(?:///?)?)?' // protocol, optionally match '//(/)'
+    + '(?:(?<protocol>[^:/?#]+:)(?:///?/?)?)?' // protocol, optionally match '//(/)'
     + '(?:' // wrap host portions in an optional match, allows matching path/query/hash only
     + '(?:(?<userinfo>[^\\\\/?#]*)@)?' // username+password
     + '(?<hostname>[^\\\\/?#:]*?)' // hostname


### PR DESCRIPTION
## Description
Optionally match periods and an additional slash in protocols.
Fixes a regression in redirect url entry, particularly for native redirect urls.

## Related Tickets & Documents
#218 

