### PR TITLE
OIDC Guides Revamp

### DIFF
--- a/docs/OIDC-Guides.md
+++ b/docs/OIDC-Guides.md
@@ -11,22 +11,26 @@ In the guides below, there may be omitted options when those options are set to 
 > [!NOTE]
 > Public clients can be configured by selecting the `None (Public)` option from the `Auth Method` dropdown on the OIDC Client page. These clients do not require a Client Secret but do require PKCE, which your Public Client Application should provide.
 
+<br>
+
 ## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/actual-budget.svg" width="28" /> Actual Budget
 
-Actual Budget can be set up to use VoidAuth as an OIDC Provider in three ways, through Environment Variables, Web GUI, or Config File. Please see the [Actaul Budget - Authenticating With an OpenID Provider](https://actualbudget.org/docs/config/oauth-auth/) for the details of both options.
+Actual Budget can be set up to use VoidAuth as an OIDC Provider in three ways: through Environment Variables, Web GUI, or Config File. See the [Actual Budget OAuth Documentation](https://actualbudget.org/docs/config/oauth-auth/) for full details.
 
-Actual Budget OIDC Setup Environment Variables:
+**Environment Variables:**
 
+```bash
+ACTUAL_OPENID_DISCOVERY_URL="Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)"
+ACTUAL_OPENID_CLIENT_ID="your-client-id"
+ACTUAL_OPENID_CLIENT_SECRET="your-client-secret"
+ACTUAL_OPENID_SERVER_HOSTNAME="https://actual.example.com"
+
+# Optional
+# ACTUAL_OPENID_ENFORCE="true"
+# ACTUAL_TOKEN_EXPIRATION="never"
 ```
-ACTUAL_OPENID_DISCOVERY_URL: #Copy from OIDC Info in VoidAuth (OIDC Issuer Endpoint)
-ACTUAL_OPENID_CLIENT_ID: your-client-id
-ACTUAL_OPENID_CLIENT_SECRET: your-client-secret
-ACTUAL_OPENID_SERVER_HOSTNAME: https://actual.example.com #(VoidAuth redirects you to this)
-ACTUAL_OPENID_ENFORCE: true     #optional [true, false]
-ACTUAL_TOKEN_EXPIRATION: never  #optional [never, openid-provider, seconds] (3600 for 1 hour)
-```
 
-In VoidAuth OIDC Client Page:
+**VoidAuth OIDC Client Configuration:**
 
 ```
 Client ID: your-client-id
@@ -35,26 +39,28 @@ Client Secret: your-client-secret
 Redirect URLs: https://actual.example.com/openid/callback
 ```
 
+<br>
+
 ## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/arcane.svg" width="28" /> Arcane
 
-Arcane can be set up to use VoidAuth as an OIDC Provider in two ways, through the Web GUI or through Environment Variables. Please see the [Arcane SSO Docs](https://arcane.ofkm.dev/docs/configuration/sso) for the details of both options.
+Arcane can be set up to use VoidAuth as an OIDC Provider in two ways: through the Web GUI or through Environment Variables. See the [Arcane SSO Documentation](https://arcane.ofkm.dev/docs/configuration/sso) for full details.
 
-Arcane OIDC Setup Environment Variables:
+**Environment Variables:**
 
+```bash
+OIDC_ENABLED="true"
+OIDC_CLIENT_ID="your-client-id"
+OIDC_CLIENT_SECRET="your-client-secret"
+OIDC_ISSUER_URL="Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)"
+OIDC_SCOPES="openid email profile groups"
+OIDC_ADMIN_CLAIM="groups"
+OIDC_ADMIN_VALUE="your-admin-role"
+
+# Optional: Merge accounts by email address
+# OIDC_MERGE_ACCOUNTS="true"
 ```
-OIDC_ENABLED: true
-OIDC_CLIENT_ID: your-client-id
-OIDC_CLIENT_SECRET: your-client-secret
-OIDC_ISSUER_URL: Copy from OIDC Info in VoidAuth (OIDC Issuer Endpoint)
-OIDC_SCOPES: openid email profile groups
-OIDC_ADMIN_CLAIM: groups
-OIDC_ADMIN_VALUE: your-admin-role
 
-# Optionally merge accounts by email address
-# OIDC_MERGE_ACCOUNTS: true
-```
-
-In VoidAuth OIDC Client Page:
+**VoidAuth OIDC Client Configuration:**
 
 ```
 Client ID: your-client-id
@@ -63,19 +69,25 @@ Client Secret: your-client-secret
 Redirect URLs: https://arcane.example.com/auth/oidc/callback
 ```
 
+<br>
+
 ## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/beszel.svg" width="28" /> Beszel
 
-Follow the [OAuth Guide](https://www.beszel.dev/guide/oauth) in the Beszel Docs and select `OpenID Connect (oidc)` from the **Add Provider** dropdown. Fill out the config as follows:
+Follow the [Beszel OAuth Guide](https://beszel.dev/guide/oauth) and select `OpenID Connect (oidc)` from the **Add Provider** dropdown.
+
+**Beszel OAuth Configuration:**
+
 ```
 Client ID: your-client-id
 Client Secret: your-client-secret
-Auth URL: Copy from OIDC Info in VoidAuth (Auth Endpoint)
-Token URL: Copy from OIDC Info in VoidAuth (Token Endpoint)
+Auth URL: Copy from VoidAuth OIDC Info (Authorization Endpoint)
+Token URL: Copy from VoidAuth OIDC Info (Token Endpoint)
 Fetch user info from: User info URL
-User info URL: Copy from OIDC Info in VoidAuth (UserInfo Endpoint)
+User info URL: Copy from VoidAuth OIDC Info (UserInfo Endpoint)
 ```
 
-In VoidAuth OIDC Client Page:
+**VoidAuth OIDC Client Configuration:**
+
 ```
 Client ID: your-client-id
 Auth Method: Client Secret Basic
@@ -83,24 +95,26 @@ Client Secret: your-client-secret
 Redirect URLs: https://beszel.example.com/api/oauth2-redirect
 ```
 
+<br>
+
 ## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/cloudflare.svg" width="28" /> Cloudflare ZeroTrust
 
-In Cloudflare:
+Navigate to the **[Cloudflare ZeroTrust Dashboard](https://dash.teams.cloudflare.com)** > **Settings** > **Authentication**. In the `Login methods` tab, select `Add new` and choose `OpenID Connect`.
 
-1. Navigate to the **[Cloudflare ZeroTrust Dashboard](https://dash.teams.cloudflare.com)** > **Settings** > **Authentication**
-2. In the `Login methods` tab, select `Add new`
-3. Choose `OpenID Connect`
-4. Fill out the form as follows:
-    - Name: `VoidAuth`
-    - App ID: `your-client-id`
-    - Client secret: `your-client-secret`
-    - Auth URL: `Copy from OIDC Info in VoidAuth (Authorization Endpoint)`
-    - Token URL: `Copy from OIDC Info in VoidAuth (Token Endpoint)`
-    - Certificate URL: `Copy from OIDC Info in VoidAuth (JWKs Endpoint)`
-    - Proof Key for Code Exchange (PKCE): `ON`
-    - Optional configurations > OIDC Claims: `mail, preferred_username`
+**Cloudflare Configuration:**
 
-In VoidAuth OIDC Client Page:
+```
+Name: VoidAuth
+App ID: your-client-id
+Client secret: your-client-secret
+Auth URL: Copy from VoidAuth OIDC Info (Authorization Endpoint)
+Token URL: Copy from VoidAuth OIDC Info (Token Endpoint)
+Certificate URL: Copy from VoidAuth OIDC Info (JWKs Endpoint)
+Proof Key for Code Exchange (PKCE): ON
+OIDC Claims: mail, preferred_username
+```
+
+**VoidAuth OIDC Client Configuration:**
 
 ```
 Client ID: your-client-id
@@ -109,20 +123,23 @@ Client Secret: your-client-secret
 Redirect URLs: https://your-team-name.cloudflareaccess.com/cdn-cgi/access/callback
 ```
 
+<br>
+
 ## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/dawarich.svg" width="28" /> Dawarich
 
+See [Dawarich v0.36.0 release notes](https://github.com/Freika/dawarich/discussions/1969) for more details on OIDC environment variables.
 
-In your `docker-compose.yml` file, add the following environment variables to the Dawarich service:
+**Environment Variables:**
+
+```bash
+OIDC_CLIENT_ID="your-client-id"
+OIDC_CLIENT_SECRET="your-client-secret"
+OIDC_ISSUER="Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)"
+OIDC_REDIRECT_URI="https://dawarich.example.com/users/auth/openid_connect/callback"
 ```
-OIDC_CLIENT_ID=your-client-id
-OIDC_CLIENT_SECRET=your-client-secret
-OIDC_ISSUER=Copy from OIDC Info in VoidAuth (OIDC Issuer Endpoint)
-OIDC_REDIRECT_URI=https://dawarich.example.com/users/auth/openid_connect/callback
-```
 
-See [release notes for v0.36.0](https://github.com/Freika/dawarich/discussions/1969) for more details on environment variables.
+**VoidAuth OIDC Client Configuration:**
 
-In VoidAuth OIDC Client Page:
 ```
 Client ID: your-client-id
 Auth Method: Client Secret Basic
@@ -130,18 +147,20 @@ Client Secret: your-client-secret
 Redirect URLs: https://dawarich.example.com/users/auth/openid_connect/callback
 ```
 
+<br>
+
 ## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/grist.svg" width="28" /> Grist
 
-Grist OIDC Setup Environment Variables:
+**Environment Variables:**
 
-```
-GRIST_OIDC_IDP_ISSUER: Copy from OIDC Info in VoidAuth (OIDC Issuer Endpoint)
-GRIST_OIDC_IDP_CLIENT_ID: your-client-id
-GRIST_OIDC_IDP_CLIENT_SECRET: your-client-secret
-GRIST_OIDC_SP_IGNORE_EMAIL_VERIFIED: true
+```bash
+GRIST_OIDC_IDP_ISSUER="Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)"
+GRIST_OIDC_IDP_CLIENT_ID="your-client-id"
+GRIST_OIDC_IDP_CLIENT_SECRET="your-client-secret"
+GRIST_OIDC_SP_IGNORE_EMAIL_VERIFIED="true"
 ```
 
-In VoidAuth OIDC Client Page:
+**VoidAuth OIDC Client Configuration:**
 
 ```
 Client ID: your-client-id
@@ -151,20 +170,22 @@ Redirect URLs: https://grist.example.com/oauth2/callback
 PostLogout URL: https://grist.example.com/signed-out
 ```
 
+<br>
+
 ## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/immich.svg" width="28" /> Immich
 
-In Immich:
+Navigate to **Administration** > **Settings** > **OAuth Settings** in Immich. See the [Immich OAuth Documentation](https://immich.app/docs/administration/oauth) for full details.
 
-**Administration** > **Settings** > **OAuth Settings**
+**Immich OAuth Configuration:**
 
 ```
-Issuer URL: Copy from OIDC Info in VoidAuth (Well-Known Endpoint)
+Issuer URL: Copy from VoidAuth OIDC Info (Well-Known Endpoint)
 Client ID: your-client-id
 Client Secret: your-client-secret
 Scope: openid profile email
 ```
 
-In VoidAuth OIDC Client Page:
+**VoidAuth OIDC Client Configuration:**
 
 ```
 Client ID: your-client-id
@@ -176,18 +197,21 @@ Redirect URLs:
   - app.immich:///oauth-callback
 ```
 
-## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/jellyfin.svg" width="28" /> Jellyfin
-In Jellyfin:
+<br>
 
-1. Follow the instructions in the [Jellyfin SSO Plugin](https://github.com/9p4/jellyfin-plugin-sso) repository to install it.
-    1. Navigate in Jellyfin to **Dashboard** > **Plugins** > **Catalog** > **Repositories**/**Gear Icon**
-    2. Add a repository, (+) button
-        * Name: Jellyfin SSO
-        * URL: https://raw.githubusercontent.com/9p4/jellyfin-plugin-sso/manifest-release/manifest.json
-    3. Save
-    4. From **Dashboard** > **Plugins** > **Catalog** Install **SSO-Auth**, Restart Jellyfin
-2. Navigate to **Dashboard** > **Plugins** > **My Plugins** > **SSO-Auth**
-3. Fill out the OID Provider form as follows and Save:
+## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/jellyfin.svg" width="28" /> Jellyfin
+
+Install the [Jellyfin SSO Plugin](https://github.com/9p4/jellyfin-plugin-sso). Navigate to **Dashboard** > **Plugins** > **Catalog** > **Repositories** and add:
+
+```
+Name: Jellyfin SSO
+URL: https://raw.githubusercontent.com/9p4/jellyfin-plugin-sso/manifest-release/manifest.json
+```
+
+Install **SSO-Auth** from the Catalog and restart Jellyfin. Then navigate to **Dashboard** > **Plugins** > **My Plugins** > **SSO-Auth**:
+
+**Jellyfin SSO-Auth Configuration:**
+
 ```
 Name: VoidAuth
 OID Endpoint: Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)
@@ -203,9 +227,9 @@ Request Additional Scopes: groups
 Set default username claim: preferred_username
 Scheme Override: https
 ```
-4. Follow the instructions on the [Jellyfin SSO Plugin](https://github.com/9p4/jellyfin-plugin-sso) repository for how to make an SSO Login button on the Jellyfin Login page.
 
-In VoidAuth OIDC Client Page:
+**VoidAuth OIDC Client Configuration:**
+
 ```
 Client ID: your-client-id
 Auth Method: Client Secret Post
@@ -213,282 +237,29 @@ Client Secret: your-client-secret
 Redirect URLs: https://jellyfin.example.com/sso/OID/redirect/VoidAuth
 ```
 
-## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/png/manyfold.png" width="28" /> Manyfold
+> [!TIP]
+> Follow the instructions on the [Jellyfin SSO Plugin](https://github.com/9p4/jellyfin-plugin-sso) repository for how to make an SSO Login button on the Jellyfin Login page.
 
-Manyfold OIDC Setup Environment Variables:
-
-```
-MULTIUSER: true
-PUBLIC_HOSTNAME: manyfold.example.com
-OIDC_CLIENT_ID: your-client-id
-OIDC_CLIENT_SECRET: your-client-secret
-OIDC_ISSUER: Copy from OIDC Info in VoidAuth (OIDC Issuer Endpoint)
-OIDC_NAME: VoidAuth
-# Optional:
-# FORCE_OIDC: true
-```
-
-In VoidAuth OIDC Client Page:
-
-```
-Client ID: your-client-id
-Auth Method: Client Secret Basic
-Client Secret: your-client-secret
-Redirect URLs: https://manyfold.example.com/users/auth/openid_connect/callback
-```
-
-
-## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/mastodon.svg" width="28" /> Mastodon
-
-Mastodon OIDC Setup Environment Variables:
-
-```
-OIDC_ENABLED: true
-OIDC_DISCOVERY: true
-OIDC_ISSUER: Copy from OIDC Info in VoidAuth (OIDC Issuer Endpoint)
-OIDC_DISPLAY_NAME: VoidAuth
-OIDC_CLIENT_ID: your-client-id
-OIDC_CLIENT_SECRET: your-client-secret
-OIDC_SCOPE: openid,profile,email
-OIDC_UID_FIELD: preferred_username
-OIDC_REDIRECT_URI: https://mastodon.example.com/auth/auth/openid_connect/callback
-OIDC_SECURITY_ASSUME_EMAIL_IS_VERIFIED: true
-# Optional:
-# ALLOW_UNSAFE_AUTH_PROVIDER_REATTACH: true
-```
-
-In VoidAuth OIDC Client Page:
-
-```
-Client ID: your-client-id
-Auth Method: Client Secret Basic
-Client Secret: your-client-secret
-Redirect URLs: https://mastodon.example.com/auth/auth/openid_connect/callback
-```
-
-
-## <img src="https://raw.githubusercontent.com/usememos/.github/refs/heads/main/assets/logo-rounded.png" width="28" /> Memos
-
-1. Connect to Memos as an admin user
-2. Click on the *user icon* at the bottom left, then on *Settings*, and finally on *SSO*
-3. Click on the *Create* button and select *Custom* from the *Template* menu
-4. Fill, customize and save these fields in the new configuration:
-
-```
-Client ID : your-client-id
-Client Secret : your-client-secret
-Authorization endpoint : Copy from OIDC Info in VoidAuth (Authorization Endpoint)
-Token endpoint : Copy from OIDC Info in VoidAuth (Token Endpoint)
-User endpoint : Copy from OIDC Info in VoidAuth (UserInfo Endpoint)
-Scopes : openid profile email offline_access
-Identifier : preferred_username
-Display Name : name
-Email : email
-```
-
-> [!NOTE]
-> Scopes are separated by spaces, **not** by commas
-
-In VoidAuth OIDC Client Page:
-
-```
-Client ID: your-client-id
-Auth Method: Client Secret Post
-Client Secret: your-client-secret
-Redirect URLs: https://memos.example.com/auth/callback
-```
-
-## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/open-webui.svg" width="28" /> Open WebUI
-
-In the following example only users in VoidAuth with the group `users` or `admins` will be able to log in. Adjust these group names as needed.
-
-Open WebUI OIDC Setup Environment Variables:
-
-```
-WEBUI_URL: https://openwebui.example.com
-ENABLE_OAUTH_SIGNUP: true
-OAUTH_MERGE_ACCOUNTS_BY_EMAIL: true
-OAUTH_CLIENT_ID: your-client-id
-OAUTH_CLIENT_SECRET: your-client-secret
-OPENID_PROVIDER_URL: Copy from OIDC Info in VoidAuth (Well-Known Endpoint)
-OAUTH_PROVIDER_NAME: VoidAuth
-OAUTH_SCOPES: openid profile groups email
-ENABLE_OAUTH_ROLE_MANAGEMENT: true
-OAUTH_ROLES_CLAIM: groups
-OAUTH_ALLOWED_ROLES: users,admins
-OAUTH_ADMIN_ROLES: admins
-```
-
-In VoidAuth OIDC Client Page:
-
-```
-Client ID: your-client-id
-Auth Method: Client Secret Basic
-Client Secret: your-client-secret
-Redirect URLs: https://openwebui.example.com/oauth/oidc/callback
-```
-
-## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/portainer.svg" width="28" /> Portainer
-In Portainer:
-**Settings** > **Authenticate**
-1. Select **OAuth** from the Authentication Methods
-2. Select **Custom** OAuth Provider
-3. Fill the OAuth Configuration form as follows:
-```
-Client ID: your-client-id
-Client secret: your-client-secret
-Authorization URL: Copy from OIDC Info in VoidAuth (Authorization Endpoint)
-Access token URL: Copy from OIDC Info in VoidAuth (Token Endpoint)
-Resource URL: Copy from OIDC Info in VoidAuth (UserInfo Endpoint)
-Redirect URL: https://portainer.example.com
-User identifier: preferred_username
-Scopes: openid profile groups email
-Auth Style: In Params
-```
-> [!NOTE]
-> Scopes are separated by spaces, **not** by commas
-
-In VoidAuth Create OIDC Client:
-
-```
-Client ID: your-client-id
-Auth Method: Client Secret Post
-Client Secret: your-client-secret
-Redirect URLs: https://portainer.example.com
-```
-Screenshot(s):
-<p align=center>
-<img width="1400" src="/public/screenshots/f7cf9712-4259-43ce-bde1-fbe22a447763.png" />
-</p>
-
-## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/proxmox.svg" width="28" /> Proxmox PVE
-
-Proxmox PVE can be set up to use VoidAuth as an OIDC Provider in two ways, through Web GUI or Config File. Please see the [Proxmox - PVE Authentication Realms](https://pve.proxmox.com/wiki/User_Management#pveum_authentication_realms) for the details.
-
-Login to your Proxmox PVE
-Under Server View side panel, click Datacenter
-Under the second side panel, click Permissions > Realms
-Under the Realms panel, click Add > OpenID Connect Server
-
-```
-Issuer URL: https://auth.example.com/oidc (VoidAuth OIDC Issuer Endpoint)
-Realm: VoidAuth (Any name you want)
-Client ID: your-client-id
-Client Key: your-client-secret
-Scopes: (leave default [email, profile])
-Username Claim: [subject, email, username] (default is sub, choose carefully)
-Prompt: Auth-Provider Default (leave default)
-```
-
-Optional:
-```
-Default: (Make VoidAuth your default provider)
-Autocreate Users: (Advanced)
-Autocreate Groups: (Advanced)
-Groups Claim: (Advanced)
-Overright Groups: (Advanced)
-```
-
-If you are not using Autocreate, you will need to to create Groups and Users manually. PVE permissions can be quite complicated. We recommend following through their Wiki as each setup requires it's own set.
-
-In VoidAuth OIDC Client Page:
-
-```
-Client ID: your-client-id
-Auth Method: Client Secret Post
-Client Secret: your-client-secret
-Redirect URLs: https://pve.example.com
-```
-Screenshot(s):
-<p align=center>
-<img width="600" src="/public/screenshots/proxmox-pve-openid.png" />
-</p>
-
-
-## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/bytestash.svg" width="28" /> ByteStash
-
-ByteStash OIDC Setup Environment Variables:
-
-```
-OIDC_ENABLED: "true"
-OIDC_DISPLAY_NAME: VoidAuth
-OIDC_ISSUER_URL: Copy from OIDC Info in VoidAuth (OIDC Issuer Endpoint)
-OIDC_CLIENT_ID: your-client-id
-OIDC_CLIENT_SECRET: your-client-secret
-OIDC_SCOPES: openid profile email groups
-
-# Optional: Disable internal accounts to force OIDC-only authentication
-# DISABLE_INTERNAL_ACCOUNTS: "true"
-```
-
-In VoidAuth OIDC Client Page:
-
-```
-Client ID: your-client-id
-Auth Method: Client Secret Post
-Client Secret: your-client-secret
-Redirect URLs: https://bytestash.example.com/api/auth/callback
-```
-
-
-## <img src="https://dockhand.pro/images/logo-dark.webp" width="28" /> Dockhand
-
-In Dockhand:
-
-1. Navigate to **Settings** > **Authentication** > **SSO**
-2. Click **Add provider**
-3. Fill in the configuration:
-```
-Name: VoidAuth
-Issuer URL: Copy from OIDC Info in VoidAuth (OIDC Issuer Endpoint)
-Client ID: your-client-id
-Client Secret: your-client-secret
-Redirect URI: https://dockhand.example.com/api/auth/oidc/callback
-Scopes: openid profile email groups
-```
-
-Optional Claim Mappings:
-```
-Username claim: preferred_username
-Email claim: email
-Display name claim: name
-```
-
-In VoidAuth OIDC Client Page:
-```
-Client ID: your-client-id
-Auth Method: Client Secret Basic
-Client Secret: your-client-secret
-Redirect URLs: https://dockhand.example.com/api/auth/oidc/callback
-```
-
-> [!NOTE]
-> For role-based access control and group mapping features, an Enterprise license is required. See the [Dockhand OIDC Configuration Guide](https://dockhand.pro/manual/#appendix-oidc) for detailed setup instructions.
-
+<br>
 
 ## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/jellyseerr.svg" width="28" /> Jellyseerr (Experimental)
 
-> [!CAUTION]
-> OIDC support in Jellyseerr is currently **experimental** and only available in the preview image: `fallenbagel/jellyseerr:preview-OIDC`. This feature is under active development and may have bugs or breaking changes.
+Navigate to **Settings** from the left-hand menu in Jellyseerr. Scroll to the **OpenID Connect** section. See the [Jellyseerr OIDC Discussion](https://github.com/fallenbagel/jellyseerr/discussions/1529) for more details.
 
-In Jellyseerr:
-
-1. Navigate to **Settings** from the left-hand menu
-2. Scroll to the **OpenID Connect** section
-3. Configure the following:
+**Jellyseerr OpenID Connect Configuration:**
 
 ```
 Enable OpenID Connect Sign-In: ☑ (checked)
 Display Name: VoidAuth
-Issuer URL: Copy from OIDC Info in VoidAuth (OIDC Issuer Endpoint)
+Issuer URL: Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)
 Client ID: your-client-id
 Client Secret: your-client-secret
 Scopes: openid profile email groups
 ```
 
-4. Scroll down and click **Save Changes**
+Scroll down and click **Save Changes**.
 
-In VoidAuth OIDC Client Page:
+**VoidAuth OIDC Client Configuration:**
 
 ```
 Client ID: your-client-id
@@ -497,43 +268,309 @@ Client Secret: your-client-secret
 Redirect URLs: https://jellyseerr.example.com/login?provider=voidauth&callback=true
 ```
 
+> [!CAUTION]
+> OIDC support in Jellyseerr is currently **experimental** and only available in the preview image: `fallenbagel/jellyseerr:preview-OIDC`. This feature is under active development and may have bugs or breaking changes.
+
 > [!TIP]
 > - If running behind a reverse proxy, enable **Proxy Support** in Jellyseerr settings
 > - Ensure proper HTTP/HTTPS scheme configuration to avoid redirect URI issues
-> - For more details, see the [Jellyseerr OIDC Discussion](https://github.com/fallenbagel/jellyseerr/discussions/1529)
 
 > [!NOTE]
 > Jellyseerr is being merged into a unified repository at [seerr-team/seerr](https://github.com/seerr-team/seerr). This documentation will be updated once the merge is complete and OIDC support is available in the stable release.
 
-## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/seafile.svg" width="28" /> Seafile
+<br>
 
-In Seafile, add these lines to the configuration file named `seahub_settings.py`:
+## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/png/manyfold.png" width="28" /> Manyfold
+
+**Environment Variables:**
+
+```bash
+MULTIUSER="true"
+PUBLIC_HOSTNAME="manyfold.example.com"
+OIDC_CLIENT_ID="your-client-id"
+OIDC_CLIENT_SECRET="your-client-secret"
+OIDC_ISSUER="Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)"
+OIDC_NAME="VoidAuth"
+
+# Optional: Force OIDC login
+# FORCE_OIDC="true"
+```
+
+**VoidAuth OIDC Client Configuration:**
 
 ```
+Client ID: your-client-id
+Auth Method: Client Secret Basic
+Client Secret: your-client-secret
+Redirect URLs: https://manyfold.example.com/users/auth/openid_connect/callback
+```
+
+<br>
+
+## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/mastodon.svg" width="28" /> Mastodon
+
+**Environment Variables:**
+
+```bash
+OIDC_ENABLED="true"
+OIDC_DISCOVERY="true"
+OIDC_ISSUER="Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)"
+OIDC_DISPLAY_NAME="VoidAuth"
+OIDC_CLIENT_ID="your-client-id"
+OIDC_CLIENT_SECRET="your-client-secret"
+OIDC_SCOPE="openid,profile,email"
+OIDC_UID_FIELD="preferred_username"
+OIDC_REDIRECT_URI="https://mastodon.example.com/auth/auth/openid_connect/callback"
+OIDC_SECURITY_ASSUME_EMAIL_IS_VERIFIED="true"
+
+# Optional: Allow reattaching auth providers
+# ALLOW_UNSAFE_AUTH_PROVIDER_REATTACH="true"
+```
+
+**VoidAuth OIDC Client Configuration:**
+
+```
+Client ID: your-client-id
+Auth Method: Client Secret Basic
+Client Secret: your-client-secret
+Redirect URLs: https://mastodon.example.com/auth/auth/openid_connect/callback
+```
+
+<br>
+
+## <img src="https://raw.githubusercontent.com/usememos/.github/refs/heads/main/assets/logo-rounded.png" width="28" /> Memos
+
+Connect to Memos as an admin user. Click on the user icon at the bottom left, then on **Settings**, and finally on **SSO**. Click on the **Create** button and select **Custom** from the **Template** menu.
+
+**Memos SSO Configuration:**
+
+```
+Client ID: your-client-id
+Client Secret: your-client-secret
+Authorization endpoint: Copy from VoidAuth OIDC Info (Authorization Endpoint)
+Token endpoint: Copy from VoidAuth OIDC Info (Token Endpoint)
+User endpoint: Copy from VoidAuth OIDC Info (UserInfo Endpoint)
+Scopes: openid profile email offline_access
+Identifier: preferred_username
+Display Name: name
+Email: email
+```
+
+**VoidAuth OIDC Client Configuration:**
+
+```
+Client ID: your-client-id
+Auth Method: Client Secret Post
+Client Secret: your-client-secret
+Redirect URLs: https://memos.example.com/auth/callback
+```
+
+> [!NOTE]
+> Scopes are separated by spaces, **not** by commas.
+
+<br>
+
+## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/open-webui.svg" width="28" /> Open WebUI
+
+In the following example, only users in VoidAuth with the group `users` or `admins` will be able to log in. Adjust these group names as needed.
+
+**Environment Variables:**
+
+```bash
+WEBUI_URL="https://openwebui.example.com"
+ENABLE_OAUTH_SIGNUP="true"
+OAUTH_MERGE_ACCOUNTS_BY_EMAIL="true"
+OAUTH_CLIENT_ID="your-client-id"
+OAUTH_CLIENT_SECRET="your-client-secret"
+OPENID_PROVIDER_URL="Copy from VoidAuth OIDC Info (Well-Known Endpoint)"
+OAUTH_PROVIDER_NAME="VoidAuth"
+OAUTH_SCOPES="openid profile groups email"
+ENABLE_OAUTH_ROLE_MANAGEMENT="true"
+OAUTH_ROLES_CLAIM="groups"
+OAUTH_ALLOWED_ROLES="users,admins"
+OAUTH_ADMIN_ROLES="admins"
+```
+
+**VoidAuth OIDC Client Configuration:**
+
+```
+Client ID: your-client-id
+Auth Method: Client Secret Basic
+Client Secret: your-client-secret
+Redirect URLs: https://openwebui.example.com/oauth/oidc/callback
+```
+
+<br>
+
+## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/portainer.svg" width="28" /> Portainer
+
+Navigate to **Settings** > **Authenticate** in Portainer. Select **OAuth** from the Authentication Methods, then select **Custom** OAuth Provider.
+
+**Portainer OAuth Configuration:**
+
+```
+Client ID: your-client-id
+Client secret: your-client-secret
+Authorization URL: Copy from VoidAuth OIDC Info (Authorization Endpoint)
+Access token URL: Copy from VoidAuth OIDC Info (Token Endpoint)
+Resource URL: Copy from VoidAuth OIDC Info (UserInfo Endpoint)
+Redirect URL: https://portainer.example.com
+User identifier: preferred_username
+Scopes: openid profile groups email
+Auth Style: In Params
+```
+
+**VoidAuth OIDC Client Configuration:**
+
+```
+Client ID: your-client-id
+Auth Method: Client Secret Post
+Client Secret: your-client-secret
+Redirect URLs: https://portainer.example.com
+```
+
+> [!NOTE]
+> Scopes are separated by spaces, **not** by commas.
+
+<p align=center>
+<img width="1400" src="/public/screenshots/f7cf9712-4259-43ce-bde1-fbe22a447763.png" />
+</p>
+
+<br>
+
+## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons@main/svg/proxmox.svg" width="28" /> Proxmox PVE
+
+Proxmox PVE can be set up to use VoidAuth as an OIDC Provider in two ways: through Web GUI or Config File. See the [Proxmox PVE Authentication Realms Documentation](https://pve.proxmox.com/wiki/User_Management#pveum_authentication_realms) for full details.
+
+Login to your Proxmox PVE. Under Server View side panel, click **Datacenter**. Under the second side panel, click **Permissions** > **Realms**. Under the Realms panel, click **Add** > **OpenID Connect Server**.
+
+**Proxmox OpenID Connect Configuration:**
+
+```
+Issuer URL: Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)
+Realm: VoidAuth
+Client ID: your-client-id
+Client Key: your-client-secret
+Scopes: email profile
+Username Claim: preferred_username
+Prompt: Auth-Provider Default
+
+# Optional
+# Default: (Make VoidAuth your default provider)
+# Autocreate Users: (Advanced)
+# Autocreate Groups: (Advanced)
+# Groups Claim: (Advanced)
+# Override Groups: (Advanced)
+```
+
+**VoidAuth OIDC Client Configuration:**
+
+```
+Client ID: your-client-id
+Auth Method: Client Secret Post
+Client Secret: your-client-secret
+Redirect URLs: https://pve.example.com
+```
+
+> [!NOTE]
+> If you are not using Autocreate, you will need to create Groups and Users manually. PVE permissions can be quite complicated. We recommend following through their Wiki as each setup requires its own set.
+
+<p align=center>
+<img width="600" src="/public/screenshots/proxmox-pve-openid.png" />
+</p>
+
+<br>
+
+## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/bytestash.svg" width="28" /> ByteStash
+
+**Environment Variables:**
+
+```bash
+OIDC_ENABLED="true"
+OIDC_DISPLAY_NAME="VoidAuth"
+OIDC_ISSUER_URL="Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)"
+OIDC_CLIENT_ID="your-client-id"
+OIDC_CLIENT_SECRET="your-client-secret"
+OIDC_SCOPES="openid profile email groups"
+
+# Optional: Disable internal accounts to force OIDC-only authentication
+# DISABLE_INTERNAL_ACCOUNTS="true"
+```
+
+**VoidAuth OIDC Client Configuration:**
+
+```
+Client ID: your-client-id
+Auth Method: Client Secret Post
+Client Secret: your-client-secret
+Redirect URLs: https://bytestash.example.com/api/auth/callback
+```
+
+<br>
+
+## <img src="https://dockhand.pro/images/logo-dark.webp" width="28" /> Dockhand
+
+Navigate to **Settings** > **Authentication** > **SSO** in Dockhand. Click **Add provider**. See the [Dockhand OIDC Configuration Guide](https://dockhand.pro/manual/#appendix-oidc) for detailed setup instructions.
+
+**Dockhand SSO Configuration:**
+
+```
+Name: VoidAuth
+Issuer URL: Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)
+Client ID: your-client-id
+Client Secret: your-client-secret
+Redirect URI: https://dockhand.example.com/api/auth/oidc/callback
+Scopes: openid profile email groups
+
+# Optional Claim Mappings
+Username claim: preferred_username
+Email claim: email
+Display name claim: name
+```
+
+**VoidAuth OIDC Client Configuration:**
+
+```
+Client ID: your-client-id
+Auth Method: Client Secret Basic
+Client Secret: your-client-secret
+Redirect URLs: https://dockhand.example.com/api/auth/oidc/callback
+```
+
+> [!NOTE]
+> For role-based access control and group mapping features, an Enterprise license is required.
+
+<br>
+
+## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/seafile.svg" width="28" /> Seafile
+
+Add these lines to the configuration file named `seahub_settings.py`:
+
+**Seafile Configuration:**
+
+```python
 ENABLE_OAUTH = True
-OAUTH_CREATE_UNKNOWN_USER = True          #To create users not yet known to Seafile
-OAUTH_ACTIVATE_USER_AFTER_CREATION = True #To auto-activate new users
-OAUTH_ENABLE_INSECURE_TRANSPORT = False   #To allow http without ssl between Seafile and VoidAuth
+OAUTH_CREATE_UNKNOWN_USER = True
+OAUTH_ACTIVATE_USER_AFTER_CREATION = True
+OAUTH_ENABLE_INSECURE_TRANSPORT = False
 
 OAUTH_CLIENT_ID = "your-client-id"
 OAUTH_CLIENT_SECRET = "your-client-secret"
-OAUTH_REDIRECT_URL = 'https://seafile.example.com/oauth/callback/'
-OAUTH_PROVIDER_DOMAIN = 'voidauth.example.com' #Deprecated, replaced by OAUTH_PROVIDER, filled just in case.
-OAUTH_PROVIDER = 'voidauth.example.com'
-OAUTH_AUTHORIZATION_URL = 'https://voidauth.example.com/oidc/auth'
-OAUTH_TOKEN_URL = 'https://voidauth.example.com/oidc/token'
-OAUTH_USER_INFO_URL = 'https://voidauth.example.com/oidc/me'
-OAUTH_SCOPE = ["openid","profile","email",]
+OAUTH_REDIRECT_URL = "https://seafile.example.com/oauth/callback/"
+OAUTH_PROVIDER_DOMAIN = "voidauth.example.com"
+OAUTH_PROVIDER = "voidauth.example.com"
+OAUTH_AUTHORIZATION_URL = "https://voidauth.example.com/oidc/auth"
+OAUTH_TOKEN_URL = "https://voidauth.example.com/oidc/token"
+OAUTH_USER_INFO_URL = "https://voidauth.example.com/oidc/me"
+OAUTH_SCOPE = ["openid", "profile", "email"]
 OAUTH_ATTRIBUTE_MAP = {
     "sub": (True, "uid"),
     "email": (False, "email"),
     "name": (False, "name"),
 }
 ```
-> [!NOTE]
-> You will need to reboot seafile server to take the modifications into account.
 
-In VoidAuth OIDC Client Page:
+**VoidAuth OIDC Client Configuration:**
 
 ```
 Client ID: your-client-id
@@ -542,34 +579,38 @@ Client Secret: your-client-secret
 Redirect URLs: https://seafile.example.com/oauth/callback/
 ```
 
+> [!NOTE]
+> You will need to reboot Seafile server for the modifications to take effect.
+
+<br>
 
 ## <img src="https://cdn.jsdelivr.net/gh/selfhst/icons/svg/wiki-js.svg" width="28" /> WikiJS
 
-1. Connect to WikiJS portal as an admin
-2. Go to Configuration Panel, and then Authentication Tab
-3. Create a new authentication strategy using "Generic OpenID Connect / OAuth 2"
-4. Fill, customize and save these fields in the new configuration view:
+Connect to WikiJS portal as an admin. Go to Configuration Panel, and then Authentication Tab. Create a new authentication strategy using "Generic OpenID Connect / OAuth 2".
+
+**WikiJS Authentication Configuration:**
 
 ```
 Client ID: your-client-id
 Client Secret: your-client-secret
-Authorization Endpoint URL: Copy from OIDC Info in VoidAuth (Authorization Endpoint)
-Token Endpoint URL: Copy from OIDC Info in VoidAuth (Token Endpoint)
-User Info Endpoint URL: Copy from OIDC Info in VoidAuth (UserInfo Endpoint)
-Issuer: Copy from OIDC Info in VoidAuth (OIDC Issuer Endpoint)
+Authorization Endpoint URL: Copy from VoidAuth OIDC Info (Authorization Endpoint)
+Token Endpoint URL: Copy from VoidAuth OIDC Info (Token Endpoint)
+User Info Endpoint URL: Copy from VoidAuth OIDC Info (UserInfo Endpoint)
+Issuer: Copy from VoidAuth OIDC Info (OIDC Issuer Endpoint)
 Email Claim: email
 Display Name Claim: name
 Groups Claim: groups
-Logout URL: Copy from OIDC Info in VoidAuth (Logout Endpoint)
+Logout URL: Copy from VoidAuth OIDC Info (Logout Endpoint)
 ```
-> [!NOTE]
-> Make sure you enabled the authentication strategy.
 
-In VoidAuth OIDC Client Page:
+**VoidAuth OIDC Client Configuration:**
 
 ```
 Client ID: your-client-id
 Auth Method: Client Secret Post
 Client Secret: your-client-secret
-Redirect URLs: https://wikijs.example.com/login/token-given-on-wikijs-authentication-strategy-view-check-below/callback
+Redirect URLs: https://wikijs.example.com/login/{token-from-wikijs-strategy}/callback
 ```
+
+> [!NOTE]
+> Make sure you enabled the authentication strategy. The redirect URL contains a unique token that is displayed in the WikiJS authentication strategy view.


### PR DESCRIPTION
## Description
This PR revamps the OIDC-Guides.md

 - Cleanup inconsistencies in verbiage and instructions
 - Clear separation between app configuration and VoidAuth configuration
 - Added references to release notes and setup discussions where relevant
 - Every application now has a link to its official documentation where available
 - Linked to specific OIDC/OAuth setup guides
 - Got straight to the configuration with clear, concise headers
 - Removed unnecessary setup prose
 - "Auth Method" (not "Authentication Method")
 - "Client Secret" (capitalized consistently)
 - "Redirect URLs" (standardized plural)
 - "PostLogout URL" (CamelCase)
 - Every section uses identical header: "VoidAuth OIDC Client Configuration:"
 - Every app now follows the same pattern: intro > configuration > VoidAuth section > notes/tips
 - Fields in consistent order: Client ID > Auth Method > Client Secret > Redirect URLs > PostLogout URL
 - Consistent placement of external documentation links
 - All notes properly formatted with markdown alerts
 - Optional fields always marked with comments
 - Comments standardized with # prefix
 - Consistent use of colons for key-value pairs
 - All environment variables now use quotes and proper bash syntax highlighting

Added services:
 - ByteStash
 - Jellyseerr
 - Dockhand


## Related Tickets & Documents
N/A

## Screenshots
N/A See preview
