### PR TITLE
allow overriding frontend path

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -117,6 +117,7 @@ VoidAuth is configurable primarily by environment variable. The available enviro
 | APP_COLOR | `#906bc7` | Theme color, rgb format; ex. #xxyyzz | | ✅ |
 | APP_FONT | `monospace` | Font used in the web interface and sent emails. Safe fonts should be used, if a font is missing it will fallback to default. Multiple font families may be chosen in fallback-font format. ex. `APP_FONT: "Tahoma, Verdana, sans-serif"` | | |
 | CONTACT_EMAIL | | The email address used for 'Contact' links, which are shown on most end-user pages if this is set. | | |
+| FRONTEND_PATH | | The path from which to serve frontend files, if not set, the default frontend files will be used. | | |
 
 #### Database Settings
 When using the `sqlite` database adapter type, no additional database connection variables are required. You will need a mounted volume to hold the generated `db.sqlite` file, as shown in the SQLite docker compose example above.
@@ -187,4 +188,3 @@ For information on how to change the email templates used for invitations, passw
 
 ### Multi-Domain Protection
 You can secure multiple domains you own by running multiple instances of VoidAuth using the same database. They should have the same **STORAGE_KEY** and **DB_\*** variables, but may otherwise have completely different configurations. The **APP_URL** variables of each would cover a different domain. If the domains you were trying to secure were `example.com` and `your-domain.net` you might set the **APP_URL** variables like `https://auth.example.com` and `https://id.your-domain.net`. These two instances would share everything in the shared DB, including users, OIDC Apps, ProxyAuth Domains, etc.
-

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -117,7 +117,7 @@ VoidAuth is configurable primarily by environment variable. The available enviro
 | APP_COLOR | `#906bc7` | Theme color, rgb format; ex. #xxyyzz | | ✅ |
 | APP_FONT | `monospace` | Font used in the web interface and sent emails. Safe fonts should be used, if a font is missing it will fallback to default. Multiple font families may be chosen in fallback-font format. ex. `APP_FONT: "Tahoma, Verdana, sans-serif"` | | |
 | CONTACT_EMAIL | | The email address used for 'Contact' links, which are shown on most end-user pages if this is set. | | |
-| FRONTEND_PATH | | The path from which to serve frontend files, if not set, the default frontend files will be used. | | |
+| FRONTEND_PATH | | The **absoulute** path from which to serve frontend files, if not set, the default frontend files will be used. | | |
 
 #### Database Settings
 When using the `sqlite` database adapter type, no additional database connection variables are required. You will need a mounted volume to hold the generated `db.sqlite` file, as shown in the SQLite docker compose example above.

--- a/server/cli/server.ts
+++ b/server/cli/server.ts
@@ -19,7 +19,9 @@ import { logger } from '../util/logger'
 import { standardRateLimit } from '../util/rateLimit'
 
 const PROCESS_ROOT = path.dirname(process.argv[1] ?? '.')
-const FE_ROOT = path.join(PROCESS_ROOT, '../frontend/dist/browser')
+const FE_ROOT = process.env.FRONTEND_PATH
+  ? path.resolve(process.env.FRONTEND_PATH)
+  : path.join(PROCESS_ROOT, '../frontend/dist/browser')
 
 export async function serve() {
   // Do not wait for theme to generate before starting

--- a/server/cli/server.ts
+++ b/server/cli/server.ts
@@ -18,11 +18,6 @@ import { createInitialAdmin } from '../db/user'
 import { logger } from '../util/logger'
 import { standardRateLimit } from '../util/rateLimit'
 
-const PROCESS_ROOT = path.dirname(process.argv[1] ?? '.')
-const FE_ROOT = process.env.FRONTEND_PATH
-  ? path.resolve(process.env.FRONTEND_PATH)
-  : path.join(PROCESS_ROOT, '../frontend/dist/browser')
-
 export async function serve() {
   // Do not wait for theme to generate before starting
   void generateTheme()
@@ -140,7 +135,7 @@ export async function serve() {
   })
 
   // frontend
-  app.use(`${basePath()}/`, express.static(FE_ROOT, {
+  app.use(`${basePath()}/`, express.static(appConfig.FRONTEND_PATH, {
     index: false,
     fallthrough: true,
   }))
@@ -174,7 +169,8 @@ export async function serve() {
 
   function modifyIndex() {
   // add APP_TITLE
-    let index = fs.readFileSync(path.join(FE_ROOT, './index.html')).toString().replace('<title>', '<title>' + appConfig.APP_TITLE)
+    const indexPath = path.join(appConfig.FRONTEND_PATH, './index.html')
+    let index = fs.readFileSync(indexPath).toString().replace('<title>', '<title>' + appConfig.APP_TITLE)
 
     // Replace base href with path of APP_URL
     index = index.replace(/<base[^>]*href=[^>]*>/g, `<base href="${basePath()}/"/>`)

--- a/server/util/config.ts
+++ b/server/util/config.ts
@@ -3,12 +3,16 @@ import { exit } from 'node:process'
 import { booleanString } from './util'
 import { logger } from './logger'
 import * as psl from 'psl'
+import path from 'node:path'
+
+const PROCESS_ROOT = path.dirname(process.argv[1] ?? '.')
 
 // basic config for app
 class Config {
   APP_TITLE = 'VoidAuth'
   APP_URL = ''
   APP_PORT: number | string = 3000
+  FRONTEND_PATH = path.join(PROCESS_ROOT, '../frontend/dist/browser')
 
   SESSION_DOMAIN?: string
 


### PR DESCRIPTION
## Description
<!-- 
Required, DO NOT leave this blank!
This PR adds/removes/updates/fixes the feature/bug. 
-->
This PR allows setting the path to built frontend. This is to anticipate other than docker deployments where the frontend isn't necessarily in the same directory as the PROCESS_ROOT. 
