### PR TITLE
Fix Emails for Signin Cannot Be Longer than 32 Characters

### DIFF
--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -55,7 +55,7 @@ publicRouter.post('/passwordStrength',
 publicRouter.post('/send_password_reset',
   zodValidate({
     body: {
-      input: zod.string().trim(),
+      input: zod.string().trim().toLowerCase(),
     },
   }), async (req, res) => {
     const { input } = req.body

--- a/shared/api-request/LoginUser.ts
+++ b/shared/api-request/LoginUser.ts
@@ -2,7 +2,7 @@ import type { SchemaInfer } from '@shared/utils'
 import zod from 'zod'
 
 export const loginUserValidator = {
-  input: zod.string().trim().min(1).max(32).toLowerCase(),
+  input: zod.string().trim().toLowerCase(),
   password: zod.string(),
   remember: zod.boolean().optional(),
 } as const


### PR DESCRIPTION
## Description
Fix issue where long emails were not passing signin validation for username or email field.

## Related Tickets & Documents
#325 

