### PR TITLE
Passkeys Not Supplied with User Verification No Longer Satisfy MFA

### DIFF
--- a/frontend/src/app/pages/login/login.component.ts
+++ b/frontend/src/app/pages/login/login.component.ts
@@ -155,7 +155,7 @@ export class LoginComponent implements OnInit, OnDestroy {
 
   async passkeyLogin(auto: boolean) {
     try {
-      const redirect = await this.passkeyService.login(!!this.form.value.rememberMe)
+      const redirect = await this.passkeyService.login({ remember: !!this.form.value.rememberMe })
       if (redirect) {
         location.assign(redirect.location)
       }

--- a/frontend/src/app/pages/mfa/mfa.component.ts
+++ b/frontend/src/app/pages/mfa/mfa.component.ts
@@ -15,6 +15,7 @@ import { UserService } from '../../services/user.service'
 import { WebAuthnError } from '@simplewebauthn/browser'
 import { Router } from '@angular/router'
 import { TranslatePipe } from '@ngx-translate/core'
+import { loginFactors } from '@shared/user'
 
 @Component({
   selector: 'app-mfa',
@@ -62,6 +63,11 @@ export class MfaComponent implements OnInit {
           this.snackbarService.error('Could not get authenticator options.')
         }
       }
+
+      // if user has 1 factor and amr includes webauth, notify that only verified passkeys will satisfy mfa
+      if (this.user && loginFactors(this.user.amr) < 2 && this.user.amr.includes('webauthn')) {
+        this.snackbarService.message('Only Passkeys that require MFA will satisfy MFA requirements by themselves.')
+      }
     } finally {
       this.spinnerService.hide()
       this.disabled.set(false)
@@ -104,7 +110,8 @@ export class MfaComponent implements OnInit {
   async passkeyLogin() {
     this.spinnerService.show()
     try {
-      const redirect = await this.passkeyService.login()
+      // Only require verified passkey if normal passkey would not improve user's mfa level
+      const redirect = await this.passkeyService.login({ requireVerified: this.user?.amr.includes('webauthn') })
       if (redirect) {
         location.assign(redirect.location)
       }
@@ -119,7 +126,8 @@ export class MfaComponent implements OnInit {
   async passkeyRegister() {
     this.spinnerService.show()
     try {
-      const redirect = await this.passkeyService.register()
+      // Only require verified passkey if normal passkey would not improve user's mfa level
+      const redirect = await this.passkeyService.register({ requireVerified: this.user?.amr.includes('webauthn') })
       if (redirect) {
         location.assign(redirect.location)
       }

--- a/frontend/src/app/services/passkey.service.ts
+++ b/frontend/src/app/services/passkey.service.ts
@@ -82,8 +82,8 @@ export class PasskeyService {
     }
   }
 
-  private async getAuthOptions() {
-    return firstValueFrom(this.http.post<PublicKeyCredentialRequestOptionsJSON>('/api/interaction/passkey/start', null))
+  private async getAuthOptions(requireVerified?: boolean) {
+    return firstValueFrom(this.http.post<PublicKeyCredentialRequestOptionsJSON>('/api/interaction/passkey/start', { requireVerified }))
   }
 
   private async sendAuth(auth: AuthenticationResponseJSON, remember?: boolean) {
@@ -95,16 +95,19 @@ export class PasskeyService {
     return result
   }
 
-  async login(remember: boolean = false) {
-    const optionsJSON = await this.getAuthOptions()
+  async login(opts: { remember?: boolean, requireVerified?: boolean } = {}) {
+    const { remember = false, requireVerified } = opts
+    const optionsJSON = await this.getAuthOptions(requireVerified)
     const auth = await startAuthentication({ optionsJSON })
     return await this.sendAuth(auth, remember)
   }
 
-  async register() {
+  async register(opts: { requireVerified?: boolean } = {}) {
+    const { requireVerified } = opts
+
     const options = await firstValueFrom(this.http.post<PublicKeyCredentialCreationOptionsJSON>(
       '/api/interaction/passkey/registration/start',
-      null,
+      { requireVerified },
     ))
     const reg = await startRegistration({ optionsJSON: options })
     try {

--- a/server/routes/interaction.ts
+++ b/server/routes/interaction.ts
@@ -460,7 +460,9 @@ router.post('/register/passkey/start',
       return
     }
 
-    const options = await createPasskeyRegistrationOptions(interaction.uid)
+    const options = await createPasskeyRegistrationOptions({
+      uniqueId: interaction.uid,
+    })
 
     res.send(options)
   })
@@ -572,10 +574,15 @@ router.post('/register/passkey/end',
 
     await createPasskey(createdUser.id, registrationInfo, currentOptions)
 
+    const addAmr = ['webauthn']
+    if (registrationInfo.userVerified) {
+      addAmr.push('webauthn_v')
+    }
+
     // See where we need to redirect the user to, depending on config
     const redir = await loginResult(req, res, {
       userId: user.id,
-      amr: ['webauthn'],
+      amr: addAmr,
     })
 
     res.send(redir)
@@ -592,6 +599,11 @@ router.post('/register/passkey/end',
  */
 router.post('/passkey/registration/start',
   checkPrivileged,
+  zodValidate({
+    body: {
+      requireVerified: zod.boolean().optional(),
+    },
+  }),
   async (req, res) => {
     // Should only be able to register if fully logged in
     const user = req.user
@@ -603,7 +615,12 @@ router.post('/passkey/registration/start',
 
     const userPasskeys = await getUserPasskeys(user.id)
 
-    const options = await createPasskeyRegistrationOptions(user.id, user.username, userPasskeys)
+    const options = await createPasskeyRegistrationOptions({
+      uniqueId: user.id,
+      username: user.username,
+      requireVerified: req.body.requireVerified,
+      excludeCredentials: userPasskeys,
+    })
 
     res.send(options)
   },
@@ -636,9 +653,14 @@ router.post('/passkey/registration/end',
 
     await createPasskey(user.id, registrationInfo, currentOptions)
 
+    const addAmr = ['webauthn']
+    if (registrationInfo.userVerified) {
+      addAmr.push('webauthn_v')
+    }
+
     const redir = await loginResult(req, res, {
       userId: user.id,
-      amr: ['webauthn'],
+      amr: addAmr,
     })
 
     res.send(redir)
@@ -711,6 +733,11 @@ router.post('/login',
  * Start login with passkey
  */
 router.post('/passkey/start',
+  zodValidate({
+    body: {
+      requireVerified: zod.boolean().optional(),
+    },
+  }),
   async (req, res) => {
     const interaction = await getInteractionDetails(req, res)
     const session = await getSession(req, res)
@@ -727,6 +754,7 @@ router.post('/passkey/start',
     const options: PublicKeyCredentialRequestOptionsJSON = await generateAuthenticationOptions({
       rpID: passkeyRpId,
       allowCredentials: passkeys,
+      userVerification: req.body.requireVerified ? 'required' : 'preferred',
     })
 
     // (Pseudocode) Remember this challenge for this user
@@ -828,9 +856,14 @@ router.post('/passkey/end',
       return
     }
 
+    const addAmr = ['webauthn']
+    if (authenticationInfo.userVerified) {
+      addAmr.push('webauthn_v')
+    }
+
     const redir = await loginResult(req, res, {
       userId: user.id,
-      amr: ['webauthn'],
+      amr: addAmr,
       remember,
     })
 

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -124,7 +124,7 @@ publicRouter.post('/reset_password/passkey/start',
 
     const userPasskeys = await getUserPasskeys(user.id)
 
-    const options = await createPasskeyRegistrationOptions(user.id, user.username, userPasskeys)
+    const options = await createPasskeyRegistrationOptions({ uniqueId: user.id, username: user.username, excludeCredentials: userPasskeys })
 
     res.send(options)
   })

--- a/server/util/passkey.ts
+++ b/server/util/passkey.ts
@@ -12,26 +12,30 @@ const passkeyRpName = appConfig.APP_TITLE
 export const passkeyRpId = appUrl().hostname
 export const passkeyRpOrigin = appUrl().origin
 
-export async function createPasskeyRegistrationOptions(uniqueId: string, username?: string, excludeCredentials?: {
-  id: Base64URLString
-  transports?: AuthenticatorTransportFuture[]
-}[]) {
+export async function createPasskeyRegistrationOptions(opts: {
+  uniqueId: string
+  username?: string
+  requireVerified?: boolean
+  excludeCredentials?: {
+    id: Base64URLString
+    transports?: AuthenticatorTransportFuture[]
+  }[] }) {
   const options = await generateRegistrationOptions({
     rpName: passkeyRpName,
     rpID: passkeyRpId,
-    userName: username ?? '',
-    userDisplayName: username ?? '',
+    userName: opts.username ?? '',
+    userDisplayName: opts.username ?? '',
     attestationType: 'none', // attestation not supported
     // Prevent users from re-registering existing authenticators
-    excludeCredentials: excludeCredentials,
+    excludeCredentials: opts.excludeCredentials,
     authenticatorSelection: {
       // Defaults
       residentKey: 'required',
-      userVerification: 'preferred',
+      userVerification: opts.requireVerified ? 'required' : 'preferred',
     },
   })
 
-  await saveRegistrationOptions(options, uniqueId)
+  await saveRegistrationOptions(options, opts.uniqueId)
 
   return options
 }

--- a/shared/user.ts
+++ b/shared/user.ts
@@ -1,20 +1,26 @@
 import type { UserDetails } from './api-response/UserDetails'
 
 export const amrFactors = {
-  multiFactors: ['email', 'webauthn'], // something that should already require mfa to access
+  multiFactors: ['email'], // something that should already require mfa to access
   firstFactors: ['pwd'], // something you know (password, PIN)
-  secondFactors: ['totp'], // something you have or are (device, biometrics)
+  secondFactors: ['totp', 'webauthn_v'], // something you have or are (device, biometrics)
+  eitherFactors: ['webauthn'], // something that can be either first or second factor depending on context
 }
 
 export function loginFactors(amr: string[]) {
+  // clone the amr so we don't modify the original by accident
+  amr = [...amr]
+
   // Multi-factor AMRs allow access always
   if (amr.some(f => amrFactors.multiFactors.includes(f))) {
     return 2
   }
 
   // Single-factor AMRs allow access if mfa is not required, or if there is a second factor
-  if (amr.some(f => amrFactors.firstFactors.includes(f))) {
-    if (amr.some(f => amrFactors.secondFactors.includes(f))) {
+  const firstFactor = amr.find(f => amrFactors.firstFactors.includes(f)) || amr.find(f => amrFactors.eitherFactors.includes(f))
+  if (firstFactor) {
+    amr = amr.filter(f => f !== firstFactor)
+    if (amr.some(f => amrFactors.secondFactors.includes(f)) || amr.some(f => amrFactors.eitherFactors.includes(f))) {
       return 2
     }
     return 1


### PR DESCRIPTION
## Description
Passkeys Not Supplied with User Verification No Longer Satisfy MFA.
Passkey (webauthn) and passkey verification (webauthn_v) AMR have been separated. 'webauthn' can now be either first or second factor, and 'webauthn_v' counts as a second factor.

## Related Tickets & Documents
#361 

