### PR TITLE
Initial Admin Password Reset Link Instead of Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ volumes:
 After creating/updating the compose.yml file and filling in the required environment variables, run `docker compose up -d` and visit your `APP_URL` to get started.
 
 > [!IMPORTANT]
-> After VoidAuth starts for the first time, find the initial administrator username and password in the logs: `docker compose logs voidauth`. Use these credentials to log in and change the default username and password or create a separate user for yourself.
+> After VoidAuth starts for the first time, find a password reset link for the initial admin account in the logs: `docker compose logs voidauth`. Use this account and change the default username or create a separate user for yourself.
 
 > [!TIP]
 > Users are created by administrators on the Invitations page by creating a new Invitation, then sending the invitation link.

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -85,7 +85,7 @@ services:
 > The **APP_URL** environment variable **must** be set to the full external url of the VoidAuth service, ex. `APP_URL: https://auth.example.com` or `APP_URL: https://example.com/auth`
 
 > [!CAUTION]
-> During the first start of the app, the **initial admin username and password** will be shown in the logs. They will never be shown again. You will need to note them down and either change the username and password or create a user for yourself, which you should add to the **auth_admins** group. Afterwards you may delete the **auth_admin** user.
+> During the first start of the app, a **password reset link for the initial admin user** will be shown in the logs. This will never be shown again. You need to copy it, follow the link to your new VoidAuth instance, and set a password. After doing this you can either change the default username, or create a user for yourself which you can add to the **auth_admins** group.
 
 > [!IMPORTANT]
 > Any user in the **auth_admins** group will be an administrator in VoidAuth. You should make a different group for administrators of protected domains/apps.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -2,6 +2,15 @@
 
 Some common issues and their causes.
 
+### Initial Admin Reset Link Not Working
+
+#### Link Expired
+
+If it has been longer than one day since the first start of VoidAuth, the password reset link generated for the initial `auth_admin` user may be expired. You will need to either:
+
+- Generate a new password reset link for the `auth_admin` account using the VoidAuth CLI. Documentation for this can be found on the [Generate Password Reset](CLI-Commands.md#generate-password-reset) section of the CLI Commands page.
+- Remove or reset your VoidAuth database and start over. For a database with VoidAuth as its only tenant, such as a sqlite database or postgres database container, this can be as simple as deleting the database and recreating it.
+
 ### Could Not Create Session
 
 The `x-voidauth-session` or `x-voidauth-interaction` cookies could not be set. Make sure that the `APP_URL` environment variable is set to the public URL of VoidAuth, and that you are accessing the app from that URL.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,6 @@
         "@simplewebauthn/browser": "^13.3.0",
         "@types/oidc-provider": "^9.5.0",
         "@types/qrcode": "^1.5.6",
-        "generate-password-browser": "^1.1.0",
         "isomorphic-dompurify": "^3.8.0",
         "ngx-spinner": "^21.1.0",
         "qrcode": "^1.5.4",
@@ -4317,26 +4316,6 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.17",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
@@ -4451,30 +4430,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -5446,16 +5401,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/generate-password-browser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/generate-password-browser/-/generate-password-browser-1.1.0.tgz",
-      "integrity": "sha512-qsQve0rVbCqGqAfKgZwjxKUfI1d1nyd22dz+kE8gn1iw1LxGkR+Slsl79XXfm2wxuK27IkopTs5KXcOEQnhg0w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "randombytes": "^2.0.5"
-      }
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5728,26 +5673,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/ignore-walk": {
       "version": "8.0.0",
@@ -7383,15 +7308,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7589,26 +7505,6 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,6 @@
     "@simplewebauthn/browser": "^13.3.0",
     "@types/oidc-provider": "^9.5.0",
     "@types/qrcode": "^1.5.6",
-    "generate-password-browser": "^1.1.0",
     "isomorphic-dompurify": "^3.8.0",
     "ngx-spinner": "^21.1.0",
     "qrcode": "^1.5.4",

--- a/frontend/src/app/pages/admin/clients/upsert-client/upsert-client.component.ts
+++ b/frontend/src/app/pages/admin/clients/upsert-client/upsert-client.component.ts
@@ -7,7 +7,6 @@ import { ValidationErrorPipe } from '../../../../pipes/ValidationErrorPipe'
 import { ActivatedRoute, Router } from '@angular/router'
 import { SnackbarService } from '../../../../services/snackbar.service'
 import { isValidWebURLControl, isValidWildcardRedirectControl } from '../../../../validators/validators'
-import { generate } from 'generate-password-browser'
 import { CLIENT_AUTH_METHODS,
   GRANT_TYPES, RESPONSE_TYPES,
   UNIQUE_RESPONSE_TYPES,
@@ -26,6 +25,11 @@ import { TranslateService } from '@ngx-translate/core'
 
 export type TypedControls<T> = {
   [K in keyof T]-?: FormControl<Required<T>[K]>
+}
+
+export function generateBase64URLString(bytes: number) {
+  const randomString = window.crypto.getRandomValues(new Uint8Array(bytes)).reduce((data, byte) => data + String.fromCharCode(byte), '')
+  return btoa(randomString).replace(/\+/g, '-').replace(/\//g, '_')
 }
 
 @Component({
@@ -74,8 +78,8 @@ export class UpsertClientComponent implements OnInit {
       isValidWildcardRedirectControl,
       (c: AbstractControl<string | null>) => {
         const url = c.value
-        const existing = this.form.controls.redirect_uris.value
-        if (!url || !existing.length || !isValidWildcardRedirect(url)) {
+        const existing = (this.form as typeof this.form | undefined)?.controls.redirect_uris.value
+        if (!url || !existing?.length || !isValidWildcardRedirect(url)) {
           return null
         }
         const all = existing.concat([url])
@@ -108,8 +112,8 @@ export class UpsertClientComponent implements OnInit {
     disabled: false,
   }, [isValidWildcardRedirectControl, (c: AbstractControl<string>) => {
     const url = c.value
-    const existing = this.form.controls.redirect_uris.value
-    if (!url || !existing.length || !isValidWildcardRedirect(url)) {
+    const existing = (this.form as typeof this.form | undefined)?.controls.redirect_uris.value
+    if (!url || !existing?.length || !isValidWildcardRedirect(url)) {
       return null
     }
     const all = existing.concat([url])
@@ -310,11 +314,7 @@ export class UpsertClientComponent implements OnInit {
   }
 
   generateClientID() {
-    this.form.controls.client_id.setValue(generate({
-      length: 16,
-      numbers: true,
-      strict: true,
-    }))
+    this.form.controls.client_id.setValue(generateBase64URLString(12))
     this.form.controls.client_id.markAsDirty()
   }
 
@@ -327,11 +327,8 @@ export class UpsertClientComponent implements OnInit {
   }
 
   generateSecret() {
-    this.form.controls.client_secret.setValue(generate({
-      length: 32,
-      numbers: true,
-      strict: true,
-    }))
+    // generate a random base64 string
+    this.form.controls.client_secret.setValue(generateBase64URLString(24))
     this.form.controls.client_secret.markAsDirty()
   }
 

--- a/frontend/src/app/pages/login/login.component.html
+++ b/frontend/src/app/pages/login/login.component.html
@@ -11,7 +11,13 @@
       </mat-form-field>
       <mat-form-field style="padding-right: 4px">
         <mat-label>{{ "login.password.label" | translate }}</mat-label>
-        <input matInput [type]="pwdShow ? 'text' : 'password'" formControlName="password" autocomplete="current-password webauthn" />
+        <input
+          matInput
+          #passwordField
+          [type]="pwdShow ? 'text' : 'password'"
+          formControlName="password"
+          autocomplete="current-password webauthn"
+        />
         <button class="field-suffix" type="button" mat-icon-button matSuffix (click)="pwdShow = !pwdShow">
           <mat-icon fontSet="material-icons-round" matSuffix>{{ pwdShow ? "visibility" : "visibility_off" }}</mat-icon>
         </button>

--- a/frontend/src/app/pages/login/login.component.ts
+++ b/frontend/src/app/pages/login/login.component.ts
@@ -1,7 +1,7 @@
-import { Component, inject, type OnDestroy, type OnInit } from '@angular/core'
+import { ChangeDetectorRef, Component, ElementRef, inject, viewChild, type AfterViewInit, type OnDestroy, type OnInit } from '@angular/core'
 import { AuthService } from '../../services/auth.service'
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms'
-import { Router, RouterLink } from '@angular/router'
+import { ActivatedRoute, Router, RouterLink } from '@angular/router'
 import { MaterialModule } from '../../material-module'
 import { HttpErrorResponse } from '@angular/common/http'
 import { ValidationErrorPipe } from '../../pipes/ValidationErrorPipe'
@@ -29,24 +29,22 @@ import { AsyncPipe } from '@angular/common'
     AsyncPipe,
   ],
 })
-export class LoginComponent implements OnInit, OnDestroy {
+export class LoginComponent implements OnInit, AfterViewInit, OnDestroy {
   public config?: ConfigResponse
 
   public form = new FormGroup({
-    email: new FormControl<string>({
-      value: '',
-      disabled: false,
-    }, [Validators.required]),
+    email: new FormControl<string | null>(null, {
+      validators: [Validators.required],
+    }),
 
-    password: new FormControl<string>({
-      value: '',
-      disabled: false,
-    }, [Validators.required]),
+    password: new FormControl<string | null>(null, {
+      validators: [Validators.required],
+    }),
 
-    rememberMe: new FormControl<boolean>({
-      value: false,
-      disabled: false,
-    }, [Validators.required]),
+    rememberMe: new FormControl<boolean>(false, {
+      validators: [Validators.required],
+      nonNullable: true,
+    }),
   })
 
   public pwdShow: boolean = false
@@ -59,10 +57,22 @@ export class LoginComponent implements OnInit, OnDestroy {
   private spinnerService = inject(SpinnerService)
   passkeyService = inject(PasskeyService)
   private router = inject(Router)
+  private route = inject(ActivatedRoute)
+  private cd = inject(ChangeDetectorRef)
+
+  private passwordField = viewChild<ElementRef>('passwordField')
 
   async ngOnInit() {
     this.configService.getConfig().then(c => this.config = c).catch((e: unknown) => {
       throw e
+    })
+
+    this.route.queryParamMap.subscribe((p) => {
+      const username = p.get('username')
+      if (username) {
+        this.form.controls.email.setValue(username)
+        this.form.controls.email.updateValueAndValidity()
+      }
     })
 
     try {
@@ -97,19 +107,26 @@ export class LoginComponent implements OnInit, OnDestroy {
     }
   }
 
+  ngAfterViewInit(): void {
+    if (this.form.controls.email.value) {
+      (this.passwordField()?.nativeElement as HTMLInputElement | undefined)?.focus()
+      this.cd.detectChanges()
+    }
+  }
+
   ngOnDestroy(): void {
     WebAuthnAbortService.cancelCeremony()
   }
 
   async login() {
-    const { email, password, rememberMe: remember } = this.form.value
+    const { email, password, rememberMe: remember } = this.form.getRawValue()
     this.spinnerService.show()
     try {
       if (!email || !password) {
         throw new Error('Invalid email or password')
       }
 
-      const redirect = await this.authService.login({ input: email, password, remember: !!remember })
+      const redirect = await this.authService.login({ input: email, password, remember })
 
       // See if we want to ask the user to register a passkey
       try {
@@ -155,7 +172,7 @@ export class LoginComponent implements OnInit, OnDestroy {
 
   async passkeyLogin(auto: boolean) {
     try {
-      const redirect = await this.passkeyService.login({ remember: !!this.form.value.rememberMe })
+      const redirect = await this.passkeyService.login({ remember: this.form.getRawValue().rememberMe })
       if (redirect) {
         location.assign(redirect.location)
       }

--- a/frontend/src/app/pages/reset-password/reset-password.component.html
+++ b/frontend/src/app/pages/reset-password/reset-password.component.html
@@ -1,5 +1,5 @@
 <h1>{{ "reset-password.title" | translate }}</h1>
-<mat-card class="form-card">
+<mat-card class="form-card" style="max-width: 500px">
   <mat-card-content>
     <form [formGroup]="passwordForm">
       <app-password-set
@@ -12,7 +12,7 @@
       <mat-card-actions>
         <button
           mat-flat-button
-          type="button"
+          type="submit"
           (click)="send()"
           [disabled]="!passwordForm.enabled || !passwordForm.valid || !passwordForm.dirty"
         >

--- a/frontend/src/app/pages/reset-password/reset-password.component.ts
+++ b/frontend/src/app/pages/reset-password/reset-password.component.ts
@@ -93,13 +93,17 @@ export class ResetPasswordComponent {
 
       this.spinnerService.show()
 
-      await this.authService.resetPassword({
+      const { username } = await this.authService.resetPassword({
         userId: this.userid,
         challenge: this.challenge,
         newPassword: this.passwordForm.controls.newPassword.value,
       })
       this.snackbarService.message('Password Reset Complete.')
-      await this.router.navigate([REDIRECT_PATHS.LOGIN])
+      await this.router.navigate([REDIRECT_PATHS.LOGIN], {
+        queryParams: {
+          username,
+        },
+      })
     } catch (e) {
       console.error(e)
 
@@ -127,9 +131,13 @@ export class ResetPasswordComponent {
       }
       const optionsJSON = await this.authService.resetPasswordPasskeyStart({ userId, challenge })
       const registration = await startRegistration({ optionsJSON })
-      await this.authService.resetPasswordPasskeyEnd({ ...registration, userId, challenge })
+      const { username } = await this.authService.resetPasswordPasskeyEnd({ ...registration, userId, challenge })
       this.snackbarService.message('Passkey created.')
-      await this.router.navigate([REDIRECT_PATHS.LOGIN])
+      await this.router.navigate([REDIRECT_PATHS.LOGIN], {
+        queryParams: {
+          username,
+        },
+      })
     } catch (error) {
       if (error instanceof WebAuthnError && error.name === 'InvalidStateError') {
         this.snackbarService.error('Passkey already registered.')

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -14,6 +14,7 @@ import type { RegisterTotpResponse } from '@shared/api-response/RegisterTotpResp
 import type { InteractionInfo } from '@shared/api-response/InteractionInfo'
 import { oidcLoginPath } from '@shared/oidc'
 import { getCurrentHost } from './config.service'
+import type { PasswordResetResponse } from '@shared/api-response/PasswordResetResponse'
 
 @Injectable({
   providedIn: 'root',
@@ -98,7 +99,7 @@ export class AuthService {
   }
 
   async resetPassword(body: ResetPassword) {
-    return firstValueFrom(this.http.post<null>('/api/public/reset_password', body))
+    return firstValueFrom(this.http.post<PasswordResetResponse>('/api/public/reset_password', body))
   }
 
   async resetPasswordPasskeyStart(body: Omit<ResetPassword, 'newPassword'>) {
@@ -107,7 +108,7 @@ export class AuthService {
 
   async resetPasswordPasskeyEnd(body: Omit<ResetPassword, 'newPassword'> & RegistrationResponseJSON) {
     try {
-      const result = await firstValueFrom(this.http.post<null>('/api/public/reset_password/passkey/end', body))
+      const result = await firstValueFrom(this.http.post<PasswordResetResponse>('/api/public/reset_password/passkey/end', body))
       localStorage.setItem('passkey_seen', 'true')
       return result
     } catch (error) {

--- a/frontend/src/app/services/passkey.service.ts
+++ b/frontend/src/app/services/passkey.service.ts
@@ -62,14 +62,14 @@ export class PasskeyService {
     let icon: string | undefined
     if (await platformAuthenticatorIsAvailable()) {
       const { os } = UAParser(navigator.userAgent)
-      // if (os.name == 'Windows') {
+      // if (os.name === 'Windows') {
       //   name = 'Windows Hello'
       //   icon = 'sentiment_satisfied'
       // } else
-      if (os.name == 'iOS') {
+      if (os.name === 'iOS') {
         name = 'Face ID'
         icon = 'face'
-      } else if (os.name == 'macOS') {
+      } else if (os.name === 'macOS') {
         name = 'Touch ID'
         icon = 'fingerprint'
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "ejs": "^5.0.1",
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.2",
-        "generate-password": "^1.7.1",
         "helmet": "^8.1.0",
         "husky": "^9.1.7",
         "jose": "^6.2.2",
@@ -4495,12 +4494,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/generate-password": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/generate-password/-/generate-password-1.7.1.tgz",
-      "integrity": "sha512-9bVYY+16m7W7GczRBDqXE+VVuCX+bWNrfYKC/2p2JkZukFb2sKxT6E3zZ3mJGz7GMe5iRK0A/WawSL3jQfJuNQ==",
-      "license": "MIT"
     },
     "node_modules/get-amd-module-type": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ejs": "^5.0.1",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.2",
-    "generate-password": "^1.7.1",
     "helmet": "^8.1.0",
     "husky": "^9.1.7",
     "jose": "^6.2.2",

--- a/server/cli/generatePasswordReset.ts
+++ b/server/cli/generatePasswordReset.ts
@@ -1,8 +1,5 @@
-import type { PasswordReset } from '@shared/db/PasswordReset'
-import { createPasswordReset } from '../db/passwordReset'
+import { createPasswordReset, getPasswordResetURL } from '../db/passwordReset'
 import { getUserByInput } from '../db/user'
-import appConfig from '../util/config'
-import { REDIRECT_PATHS } from '@shared/constants'
 
 export async function generatePasswordReset(input: string) {
   input = input.trim()
@@ -16,9 +13,4 @@ export async function generatePasswordReset(input: string) {
   const passwordReset = await createPasswordReset(user.id)
 
   return getPasswordResetURL(passwordReset)
-}
-
-export function getPasswordResetURL(passwordReset: PasswordReset) {
-  const query = `id=${passwordReset.userId}&challenge=${passwordReset.challenge}`
-  return `${appConfig.APP_URL}/${REDIRECT_PATHS.RESET_PASSWORD}?${query}`
 }

--- a/server/db/passwordReset.ts
+++ b/server/db/passwordReset.ts
@@ -1,22 +1,27 @@
-import { TTLs, TABLES } from '@shared/constants'
+import { TTLs, TABLES, REDIRECT_PATHS } from '@shared/constants'
 import type { PasswordReset } from '@shared/db/PasswordReset'
-import { randomUUID } from 'crypto'
-import { generate } from 'generate-password'
+import { randomBytes, randomUUID } from 'crypto'
 import { db } from './db'
 import { createExpiration } from './util'
+import appConfig from '../util/config'
 
-export async function createPasswordReset(userId: string) {
+export async function createPasswordReset(userId: string, customTTL: number = 0) {
+  if (customTTL < 0) {
+    throw new Error('Invalid TTL for Password Reset.')
+  }
   const passwordReset: PasswordReset = {
     id: randomUUID(),
     userId: userId,
-    challenge: generate({
-      length: 32,
-      numbers: true,
-    }),
+    challenge: randomBytes(24).toString('base64url'),
     createdAt: new Date(),
-    expiresAt: createExpiration(TTLs.PASSWORD_RESET),
+    expiresAt: customTTL ? createExpiration(customTTL) : createExpiration(TTLs.PASSWORD_RESET),
   }
   await db().table<PasswordReset>(TABLES.PASSWORD_RESET).insert(passwordReset)
 
   return passwordReset
+}
+
+export function getPasswordResetURL(passwordReset: PasswordReset) {
+  const query = `id=${passwordReset.userId}&challenge=${passwordReset.challenge}`
+  return `${appConfig.APP_URL}/${REDIRECT_PATHS.RESET_PASSWORD}?${query}`
 }

--- a/server/db/user.ts
+++ b/server/db/user.ts
@@ -3,9 +3,8 @@ import { db } from './db'
 import type { UserGroup, Group } from '@shared/db/Group'
 import type { UserDetails, UserWithAdminIndicator } from '@shared/api-response/UserDetails'
 import type { User } from '@shared/db/User'
-import { ADMIN_USER, ADMIN_GROUP, TABLES } from '@shared/constants'
-import { randomUUID } from 'crypto'
-import { generate } from 'generate-password'
+import { ADMIN_USER, ADMIN_GROUP, TABLES, TTLs } from '@shared/constants'
+import { randomBytes, randomUUID } from 'crypto'
 import type { Flag } from '@shared/db/Flag'
 import appConfig from '../util/config'
 import type { OIDCPayload } from '@shared/db/OIDCPayload'
@@ -13,6 +12,8 @@ import { hasTOTP } from './totp'
 import { getUserPasskeys } from './passkey'
 import { argon2 } from '../util/argon2id'
 import zod from 'zod'
+import { createPasswordReset, getPasswordResetURL } from './passwordReset'
+import { humanDuration } from '@shared/utils'
 
 export async function getUsers(searchTerm?: string): Promise<UserWithAdminIndicator[]> {
   return (await db().table<User>(TABLES.USER).select<(User & { isAdmin: number })[]>('user.*', db().raw(`
@@ -128,10 +129,7 @@ export async function createInitialAdmin() {
   // Check if admin user and group have ever been created.
   const adminCreated = await db().table<Flag>(TABLES.FLAG).select().where({ name: 'ADMIN_CREATED' }).first()
   if (!zod.stringbool().safeParse(adminCreated?.value).data) {
-    const password = generate({
-      length: 32,
-      numbers: true,
-    })
+    const password = randomBytes(24).toString('hex')
 
     const initialAdminUser: User = {
       id: randomUUID(),
@@ -171,13 +169,15 @@ export async function createInitialAdmin() {
     await db().table<Flag>(TABLES.FLAG).insert({ name: 'ADMIN_CREATED', value: 'true', createdAt: new Date() })
       .onConflict(['name']).merge(['value'])
 
+    const passwordReset = await createPasswordReset(initialAdminUser.id, TTLs.DAY)
+    const resetUrl = getPasswordResetURL(passwordReset)
+
+    console.log('====================================================================================================')
     console.log('')
+    console.log(`Password reset link for the initial admin user, valid for ${humanDuration(TTLs.DAY * 1000)}:`)
     console.log('')
-    console.log('The following are the initial Admin username and password, use to create your own user.')
-    console.log('These will not be shown again:')
+    console.log(resetUrl)
     console.log('')
-    console.log(initialAdminUser.username)
-    console.log(password)
-    console.log('')
+    console.log('====================================================================================================')
   }
 }

--- a/server/db/util.ts
+++ b/server/db/util.ts
@@ -84,6 +84,11 @@ export function mergeKeys<T extends object>(inserted: T): (keyof T)[] {
   return Object.keys(inserted).filter(k => !exludedKeys.includes(k)) as (keyof T)[]
 }
 
+/**
+ * Creates expiration date from a ttl in seconds
+ * @param ttl in seconds
+ * @returns expiration date
+ */
 export function createExpiration(ttl: number) {
   return new Date(Date.now() + (ttl * 1000))
 }

--- a/server/oidc/adapter.ts
+++ b/server/oidc/adapter.ts
@@ -73,9 +73,10 @@ export class KnexAdapter implements Adapter {
         logger({
           level: 'error',
           message: 'Error occurred while parsing OIDC payload.',
-          error: e instanceof Error ? e : { message: String(e) },
+          // do not leak error details, may contain secrets
+          error: e instanceof Error ? { name: e.name } : { message: 'Error parsing OIDC payload' },
         })
-        return undefined
+        throw e
       }
     })
   }

--- a/server/oidc/provider.ts
+++ b/server/oidc/provider.ts
@@ -2,7 +2,6 @@ import Provider, { type Configuration } from 'oidc-provider'
 import { findAccount, getUserById, userRequiresMfa } from '../db/user'
 import appConfig, { appUrl, basePath, getSessionDomain, sessionDomainReaches } from '../util/config'
 import { KnexAdapter } from './adapter'
-import { generate } from 'generate-password'
 import { ADMIN_GROUP, REDIRECT_PATHS, TABLES, TTLs } from '@shared/constants'
 import { errors } from 'oidc-provider'
 import { getCookieKeys, getJWKs, makeKeysValid } from '../db/key'
@@ -17,6 +16,7 @@ import { wildcardRedirect } from '@shared/utils'
 import type { IncomingMessage, ServerResponse } from 'http'
 import { getProxyAuthWithCache } from '../db/proxyAuth'
 import { RESPONSE_TYPES } from '@shared/api-request/admin/ClientUpsert'
+import { randomBytes } from 'crypto'
 
 // Extend 'oidc-provider' where needed
 declare module 'oidc-provider' {
@@ -329,10 +329,7 @@ const configuration: Configuration = {
     {
       client_id: 'auth_internal_client',
       // unique every time, never used
-      client_secret: generate({
-        length: 32,
-        numbers: true,
-      }),
+      client_secret: randomBytes(24).toString('hex'),
       // any redirect will work, injected custom redirect_uri validator below
       redirect_uris: [appConfig.APP_URL],
       response_modes: ['query'],
@@ -342,10 +339,7 @@ const configuration: Configuration = {
     }, {
       client_id: 'proxyauth_internal_client',
       // unique every time, never used
-      client_secret: generate({
-        length: 32,
-        numbers: true,
-      }),
+      client_secret: randomBytes(24).toString('hex'),
       // special redirect checking logic, injected custom redirect_uri validator below
       redirect_uris: [appConfig.APP_URL],
       response_modes: ['query'],

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -3,7 +3,7 @@ import { db } from '../db/db'
 import { isOIDCProviderError, provider } from '../oidc/provider'
 import { clientUpsertValidator } from '@shared/api-request/admin/ClientUpsert'
 import type { User } from '@shared/db/User'
-import { randomUUID } from 'crypto'
+import { randomBytes, randomUUID } from 'crypto'
 import { getClient, getClients, removeClient, upsertClient } from '../db/client'
 import type { UserGroup, Group, InvitationGroup, ProxyAuthGroup } from '@shared/db/Group'
 import { groupUpsertValidator } from '@shared/api-request/admin/GroupUpsert'
@@ -16,7 +16,6 @@ import { getInvitation, getInvitations } from '../db/invitations'
 import type { Invitation } from '@shared/db/Invitation'
 import { invitationUpsertValidator } from '@shared/api-request/admin/InvitationUpsert'
 import { sendApproved, sendInvitation, sendPasswordReset, sendTestNotification, SMTP_VERIFIED } from '../util/email'
-import { generate } from 'generate-password'
 import type { GroupUsers } from '@shared/api-response/admin/GroupUsers'
 import type { ProxyAuth } from '@shared/db/ProxyAuth'
 import { urlFromWildcardHref } from '@shared/utils'
@@ -501,8 +500,6 @@ adminRouter.post('/users/delete',
       return
     }
 
-    await db().table<User>(TABLES.USER).update({ approved: true }).whereIn('id', users)
-
     const count = await db().table<User>(TABLES.USER).delete().whereIn('id', users)
 
     if (!count) {
@@ -672,10 +669,7 @@ adminRouter.post('/invitation',
       await db().table<Invitation>(TABLES.INVITATION).insert({
         ...invitationData,
         id,
-        challenge: generate({
-          length: 32,
-          numbers: true,
-        }),
+        challenge: randomBytes(24).toString('base64url'),
         createdBy: currentUser.id,
         updatedBy: currentUser.id,
         createdAt: new Date(),
@@ -807,7 +801,8 @@ adminRouter.post('/send_passwordreset/:id',
     },
   }), async (req, res) => {
     const { id } = req.params
-    const reset = await db().select().table<PasswordReset>(TABLES.PASSWORD_RESET).where({ id }).first()
+    const reset = await db().select().table<PasswordReset>(TABLES.PASSWORD_RESET).where({ id })
+      .andWhere('expiresAt', '>=', new Date()).first()
 
     if (!reset) {
       res.sendStatus(404)

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -46,7 +46,7 @@ authRouter.get('/invitation/:id/:challenge',
   }), async (req, res) => {
     const { id, challenge } = req.params
     const invite = await getInvitation(id)
-    if (!invite || invite.challenge != challenge) {
+    if (!invite || invite.challenge !== challenge) {
       res.sendStatus(404)
       return
     }

--- a/server/routes/interaction.ts
+++ b/server/routes/interaction.ts
@@ -7,12 +7,11 @@ import { loginUserValidator } from '@shared/api-request/LoginUser'
 import appConfig from '../util/config'
 import { verifyUserEmailValidator } from '@shared/api-request/VerifyUserEmail'
 import { sendEmailVerification } from '../util/email'
-import { generate } from 'generate-password'
 import type { EmailVerification } from '@shared/db/EmailVerification'
 import type { User } from '@shared/db/User'
 import { db } from '../db/db'
 import { registerUserValidator } from '@shared/api-request/RegisterUser'
-import { randomUUID } from 'crypto'
+import { randomBytes, randomUUID } from 'crypto'
 import { REDIRECT_PATHS, TABLES, TTLs } from '@shared/constants'
 import { type Interaction } from 'oidc-provider'
 import type { ConsentDetails } from '@shared/api-response/ConsentDetails'
@@ -1086,10 +1085,7 @@ export async function createEmailVerification(
   }
 
   // generate email verification challenge
-  const challenge = generate({
-    length: 32,
-    numbers: true,
-  })
+  const challenge = randomBytes(24).toString('base64url')
   const email_verification: EmailVerification = {
     id: randomUUID(),
     userId: user.id,

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -19,6 +19,7 @@ import { zodValidate } from '../util/zodValidate'
 import zod from 'zod'
 import { passkeyRegistrationValidator } from '../../shared/validators'
 import { userChallengeValidator } from '@shared/api-request/UserChallenge'
+import type { PasswordResetResponse } from '@shared/api-response/PasswordResetResponse'
 
 /**
  * routes that do not require any auth
@@ -107,7 +108,7 @@ publicRouter.post('/reset_password',
     await db().table<User>(TABLES.USER).update({ passwordHash: argon2.hash(newPassword) }).where({ id: user.id })
     await db().table<PasswordReset>(TABLES.PASSWORD_RESET).delete().where({ id: passwordReset.id })
     await endSessions(user.id)
-    res.send()
+    res.send({ username: user.username } satisfies PasswordResetResponse)
   })
 
 publicRouter.post('/reset_password/passkey/start',
@@ -159,5 +160,5 @@ publicRouter.post('/reset_password/passkey/end',
 
     await createPasskey(user.id, registrationInfo, currentOptions)
 
-    res.send()
+    res.send({ username: user.username } satisfies PasswordResetResponse)
   })

--- a/server/util/config.ts
+++ b/server/util/config.ts
@@ -1,4 +1,3 @@
-import { generate } from 'generate-password'
 import { exit } from 'node:process'
 import { booleanString } from './util'
 import { logger } from './logger'
@@ -8,6 +7,7 @@ import Docker from 'dockerode'
 import { clientUpsertValidator } from '@shared/api-request/admin/ClientUpsert'
 import zod from 'zod'
 import type { SecureVersion } from 'node:tls'
+import { randomBytes } from 'node:crypto'
 
 // basic config for app
 class Config {
@@ -407,27 +407,21 @@ if ('listed' in pslParsedAppUrl && !pslParsedAppUrl.listed) {
   })
 }
 
-// If SESSION_DOMAIN is set, make sure APP_URL endsWith SESSION_DOMAIN
+logger({
+  level: 'debug',
+  message: `Session Domain: '${String(getSessionDomain())}'`,
+})
+
+// If SESSION_DOMAIN is set, make sure SESSION_DOMAIN cookies reach APP_URL
 if (appConfig.SESSION_DOMAIN) {
-  const dotSD = (!appConfig.SESSION_DOMAIN.startsWith('.') ? '.' : '') + appConfig.SESSION_DOMAIN
-  if (appUrl().hostname !== appConfig.SESSION_DOMAIN && !appUrl().hostname.endsWith(dotSD)) {
+  if (!sessionDomainReaches(appUrl().hostname)) {
     logger({
       level: 'error',
       message: 'If SESSION_DOMAIN is set, the APP_URL hostname must end with the SESSION_DOMAIN.',
     })
     exit(1)
   }
-  if (appConfig.SESSION_DOMAIN !== getBaseDomain(appUrl().hostname)) {
-    logger({
-      level: 'debug',
-      message: `SESSION_DOMAIN: '${appConfig.SESSION_DOMAIN}'`,
-    })
-  }
 }
-logger({
-  level: 'debug',
-  message: `Session Domain: '${String(getSessionDomain())}'`,
-})
 
 // check DEFAULT_REDIRECT is valid if set
 if (appConfig.DEFAULT_REDIRECT && !URL.parse(appConfig.DEFAULT_REDIRECT)) {
@@ -442,10 +436,8 @@ if (appConfig.DEFAULT_REDIRECT && !URL.parse(appConfig.DEFAULT_REDIRECT)) {
 if (appConfig.STORAGE_KEY.length < 32) {
   logger({
     level: 'error',
-    message: 'STORAGE_KEY must be set and be at least 32 characters long. Use something long and random like: ' + generate({
-      length: 32,
-      numbers: true,
-    }),
+    message: 'STORAGE_KEY must be set and be at least 32 characters long. Use something long and random like: '
+      + randomBytes(24).toString('base64url'),
   })
   exit(1)
 }
@@ -492,7 +484,9 @@ export function getSessionDomain() {
 export function sessionDomainReaches(hostName: string) {
   const targetDomain = getBaseDomain(hostName)
   const sessionDomain = getSessionDomain()
-  return targetDomain === sessionDomain || (sessionDomain != null && hostName.endsWith(sessionDomain))
+  // Add dot to start of sessionDomain if it doesn't already have one, to prevent false positives
+  const dotSD = sessionDomain && !sessionDomain.startsWith('.') ? '.' + sessionDomain : sessionDomain
+  return targetDomain === sessionDomain || !dotSD || hostName.endsWith(dotSD)
 }
 
 //

--- a/server/util/email.ts
+++ b/server/util/email.ts
@@ -15,6 +15,7 @@ import type { User } from '@shared/db/User'
 import type { UserWithoutPassword } from '@shared/api-response/UserDetails'
 import ejs from 'ejs'
 import { logger } from './logger'
+import { getPasswordResetURL } from '../db/passwordReset'
 
 export let SMTP_VERIFIED = false
 const DEFAULT_EMAIL_TEMPLATE_DIR = './default_email_templates'
@@ -226,8 +227,6 @@ export async function sendPasswordReset(passwordReset: PasswordReset, user: User
     throw new Error('SMTP transport could not be validated.')
   }
 
-  const query = `id=${passwordReset.userId}&challenge=${passwordReset.challenge}`
-
   const { subject, html, text } = passwordResetTemplates({
     primary_color: PRIMARY_COLOR,
     primary_contrast_color: PRIMARY_CONTRAST_COLOR,
@@ -235,7 +234,7 @@ export async function sendPasswordReset(passwordReset: PasswordReset, user: User
     app_font: appConfig.APP_FONT,
     app_url: appConfig.APP_URL,
     name: user.name || user.username,
-    reset_url: `${appConfig.APP_URL}/${REDIRECT_PATHS.RESET_PASSWORD}?${query}`,
+    reset_url: getPasswordResetURL(passwordReset),
   })
 
   if (!subject || (!html && !text)) {

--- a/server/util/logger.ts
+++ b/server/util/logger.ts
@@ -33,7 +33,7 @@ export type LogShape = {
   }
   error?: {
     name?: string
-    message: string
+    message?: string
     stack?: string
   }
 }

--- a/shared/api-response/PasswordResetResponse.ts
+++ b/shared/api-response/PasswordResetResponse.ts
@@ -1,0 +1,3 @@
+export type PasswordResetResponse = {
+  username: string
+}

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -49,6 +49,10 @@ export const TTLs = {
   // Should be longer than or equal to any OIDC TTLs
   OIDC_JWK: 1 * YEAR,
   COOKIE_KEY: 1 * YEAR,
+
+  // Util
+  DAY: 1 * DAY,
+  YEAR: 1 * YEAR,
 } as const
 
 export const TABLES = {


### PR DESCRIPTION
## Description
- Initial admin credentials are no longer shown in the logs on first start. Instead, a password reset link is generated and shown.
- Login page will now autofill a username when it is in the query parameters, currently only set on successful password reset. 
- Remove the generate-password packages and use crypto built-in functions to do a similar job.
- Do not print error details to logs when OIDC adapter cannot parse a payload. Also when this happens throw the error instead of hiding it silently.
- Ensure session domain matching does not return false positives where input domain partially matches (eg. example.com =/= notexample.com even though notexample.com ends with example.com).
- Misc improvements and fixes
