### PR TITLE
Groups Can be Auto Assigned to New Invites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN npm run server:build
 # Build frontend
 RUN cd ./frontend && npm run build
 
-# Install external dependencies in dist folder
+# Install external dependencies that could not be bundled in dist folder
 RUN cd ./dist && npm i
 
 # 

--- a/docs/Security-Groups.md
+++ b/docs/Security-Groups.md
@@ -8,6 +8,13 @@ Security Groups are created from the admin Groups page, users can be added to gr
 > [!TIP]
 > Users with the `auth_admins` group will not be denied access to any resource, regardless of other security group restrictions.
 
+### Options
+
+Security Group settings also includes additional options:
+
+- MFA Required: Users in this group will need to use Multi-Factor Authentication to log in.
+- Auto Assign: This group will be added to new invitations by default.
+
 <p align=center>
 <img width="336" alt="image" src="/public/screenshots/91429974-7e2c-4c3a-80a4-ad25e5ea6416.png" />
 </p>

--- a/frontend/public/i18n/en-US.json
+++ b/frontend/public/i18n/en-US.json
@@ -420,7 +420,8 @@
         "users": "Users:"
       },
       "checkboxes": {
-        "mfa-required": "MFA Required"
+        "mfa-required": "MFA Required",
+        "auto-assign": "Auto Assign"
       }
     },
     "invitations": {

--- a/frontend/src/app/pages/admin/groups/group/group.component.html
+++ b/frontend/src/app/pages/admin/groups/group/group.component.html
@@ -80,6 +80,8 @@
 
       <mat-checkbox formControlName="mfaRequired">{{ "admin.group.checkboxes.mfa-required" | translate }}</mat-checkbox>
 
+      <mat-checkbox formControlName="autoAssign">{{ "admin.group.checkboxes.auto-assign" | translate }}</mat-checkbox>
+
       <mat-card-actions>
         <button mat-flat-button [disabled]="form.invalid || form.pristine" type="submit">
           @if (id) {

--- a/frontend/src/app/pages/admin/groups/group/group.component.ts
+++ b/frontend/src/app/pages/admin/groups/group/group.component.ts
@@ -46,6 +46,7 @@ export class GroupComponent {
     name: new FormControl<string | null>(null, [Validators.required, Validators.pattern('^[A-Za-z0-9_-]+$')]),
     users: new FormControl<GroupUsers['users']>([], { nonNullable: true }),
     mfaRequired: new FormControl<boolean>(false, { nonNullable: true }),
+    autoAssign: new FormControl<boolean>(false, { nonNullable: true }),
   }) satisfies FormGroup<TypedControls<Omit<GroupUpsert, 'id' | 'name'> & Nullable<Pick<GroupUpsert, 'name'>>>>
 
   private adminService = inject(AdminService)
@@ -67,6 +68,7 @@ export class GroupComponent {
           this.form.reset({
             name: group.name,
             mfaRequired: !!group.mfaRequired,
+            autoAssign: !!group.autoAssign,
             users: group.users.map((u) => {
               return { id: u.id, username: u.username }
             }),
@@ -78,6 +80,8 @@ export class GroupComponent {
 
         if (this.form.controls.name.value?.toLowerCase() === ADMIN_GROUP.toLowerCase()) {
           this.form.controls.name.disable()
+          this.form.controls.autoAssign.setValue(false)
+          this.form.controls.autoAssign.disable()
         }
       } catch (e) {
         console.error(e)

--- a/frontend/src/app/pages/admin/invitations/invitation/invitation.component.ts
+++ b/frontend/src/app/pages/admin/invitations/invitation/invitation.component.ts
@@ -82,18 +82,27 @@ export class InvitationComponent {
 
         this.config = await this.configService.getConfig()
         this.adminConfig = await this.adminService.config()
+        this.groups = (await this.adminService.groups()).map(g => g.name)
 
         if (id) {
+          // We are updating an invite
           this.id = id
           const invitation = await this.adminService.invitation(this.id)
           await this.formSet(invitation)
           this.setEmailVerifiedState()
-        } else if (this.adminConfig.defaultUserExpireDuration) {
-          const defaultExpireDate = new Date(Date.now() + this.adminConfig.defaultUserExpireDuration * 1000)
-          this.form.controls.userExpiresAt.setValue(defaultExpireDate)
+        } else {
+          // This is a new invite
+          if (this.adminConfig.defaultUserExpireDuration) {
+            const defaultExpireDate = new Date(Date.now() + this.adminConfig.defaultUserExpireDuration * 1000)
+            this.form.controls.userExpiresAt.setValue(defaultExpireDate)
+          }
+
+          if (this.adminConfig.defaultGroups.length) {
+            this.form.controls.groups.setValue(this.adminConfig.defaultGroups.sort())
+            this.form.controls.groups.markAsDirty()
+          }
         }
 
-        this.groups = (await this.adminService.groups()).map(g => g.name)
         this.groupAutoFilter()
       } catch (e) {
         console.error(e)

--- a/knexfile.js
+++ b/knexfile.js
@@ -10,5 +10,4 @@ export default {
     migrations: {
         extension: 'ts',
     },
-    client: 'pg',
 }

--- a/migrations/20260412000420_default_groups.ts
+++ b/migrations/20260412000420_default_groups.ts
@@ -1,0 +1,17 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table('group', (table) => {
+    table.boolean('autoAssign').nullable()
+  })
+  await knex.table('group').update({ autoAssign: false })
+  await knex.schema.table('group', (table) => {
+    table.dropNullable('autoAssign')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('group', (table) => {
+    table.dropColumn('autoAssign')
+  })
+}

--- a/server/db/connection.ts
+++ b/server/db/connection.ts
@@ -19,7 +19,16 @@ async function runSchemaUpdates(connectionOptions: Knex.Config) {
   // When running schema migrations with sqlite make sure foreign key checking is DISABLED to prevent data loss
   if (connectionOptions.client === 'sqlite3' || connectionOptions.client === 'better-sqlite') {
     const { pool, ...rest } = connectionOptions
-    connectionOptions = rest
+    // create new connectionOptions object with foreign key checking DISABLED
+    connectionOptions = { ...rest, pool: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      afterCreate: (conn: any, cb: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        conn.prepare('PRAGMA foreign_keys = OFF').run()
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        cb()
+      },
+    } }
   }
 
   const db = knex(connectionOptions)
@@ -28,6 +37,18 @@ async function runSchemaUpdates(connectionOptions: Knex.Config) {
   const [,migrations]: [number, string[]] = await db.migrate.latest({
     loadExtensions: ['.ts'],
   })
+  if (connectionOptions.client === 'sqlite' || connectionOptions.client === 'better-sqlite3') {
+    const violations = await db.raw<unknown[]>('PRAGMA foreign_key_check')
+    if (violations.length) {
+      logger({ level: 'error', message: 'foreign_key_check constraint violations detected in database!',
+        error: {
+          name: 'Foreign Key Check Violation',
+          message: 'foreign_key_check constraint violations detected in database!',
+        },
+      })
+    }
+    console.log(violations)
+  }
   await db.destroy()
   return migrations
 }
@@ -82,13 +103,21 @@ function connectionSQLite(): Knex.Config {
     })
   }
 
-  return {
+  const connectionOptions: Knex.Config = {
     client: 'better-sqlite3',
     connection: {
       filename: './db/db.sqlite',
     },
     useNullAsDefault: true,
-    pool: {
+    migrations: {
+      // disable transactions for db migrations, they only work for postgres anyways and cause issues with sqlite dbs
+      disableTransactions: true,
+    },
+  }
+
+  // Make sure that for sqlite DBs foreign key checking is ENABLED
+  if (connectionOptions.client === 'sqlite3' || connectionOptions.client === 'better-sqlite') {
+    connectionOptions.pool = {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       afterCreate: (conn: any, cb: any) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
@@ -96,6 +125,8 @@ function connectionSQLite(): Knex.Config {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         cb()
       },
-    },
+    }
   }
+
+  return connectionOptions
 }

--- a/server/db/user.ts
+++ b/server/db/user.ts
@@ -147,6 +147,7 @@ export async function createInitialAdmin() {
       id: randomUUID(),
       name: ADMIN_GROUP,
       mfaRequired: false,
+      autoAssign: false,
       createdBy: initialAdminUser.id,
       updatedBy: initialAdminUser.id,
       createdAt: new Date(),

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -41,9 +41,10 @@ export const adminRouter = Router()
 
 adminRouter.use(checkPrivileged, checkAdmin)
 
-adminRouter.get('/config', (_req, res) => {
+adminRouter.get('/config', async (_req, res) => {
   res.send({
     defaultUserExpireDuration: appConfig.DEFAULT_USER_EXPIRES_IN,
+    defaultGroups: (await db().table<Group>(TABLES.GROUP).select('name').where({ autoAssign: true })).map(g => g.name),
   } satisfies AdminConfig)
 })
 
@@ -548,7 +549,7 @@ adminRouter.post('/group',
       return
     }
 
-    const { id, name, mfaRequired, users } = req.body
+    const { id, name, mfaRequired, autoAssign, users } = req.body
 
     // Check for name conflict
     const conflictingGroup = await db().select()
@@ -562,26 +563,33 @@ adminRouter.post('/group',
 
     const groupId = id ?? randomUUID()
 
-    // Do not update the ADMIN_GROUP
-    if (name.toLowerCase() !== ADMIN_GROUP.toLowerCase()) {
-      const group: Group = {
-        id: groupId,
-        name,
-        mfaRequired,
-        createdBy: currentUser.id,
-        updatedBy: currentUser.id,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      }
-
-      await db().table<Group>(TABLES.GROUP).insert(group).onConflict(['id']).merge(mergeKeys(group))
-    } else {
+    // Admin group has special checks
+    if (name.toLowerCase() === ADMIN_GROUP.toLowerCase()) {
       // If this IS the ADMIN_GROUP, there should always be at least one user
       if (!users.length) {
         res.sendStatus(400)
         return
       }
+
+      // Admin group cannot be auto-assigned
+      if (autoAssign) {
+        res.sendStatus(400)
+        return
+      }
     }
+
+    const group: Group = {
+      id: groupId,
+      name,
+      mfaRequired,
+      autoAssign,
+      createdBy: currentUser.id,
+      updatedBy: currentUser.id,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+
+    await db().table<Group>(TABLES.GROUP).insert(group).onConflict(['id']).merge(mergeKeys(group))
 
     const userGroups: UserGroup[] = users.map((u) => {
       return {

--- a/shared/api-request/admin/GroupUpsert.ts
+++ b/shared/api-request/admin/GroupUpsert.ts
@@ -5,6 +5,7 @@ export const groupUpsertValidator = {
   id: zod.uuidv4().optional(),
   name: zod.string().trim().regex(new RegExp('^[A-Za-z0-9_-]+$')),
   mfaRequired: zod.boolean(),
+  autoAssign: zod.boolean(),
   users: zod.array(zod.object({
     id: zod.uuidv4(),
     username: zod.string().trim(),

--- a/shared/api-response/admin/AdminConfig.ts
+++ b/shared/api-response/admin/AdminConfig.ts
@@ -1,3 +1,4 @@
 export type AdminConfig = {
   defaultUserExpireDuration?: number
+  defaultGroups: string[] // names of auto-assigned groups
 }

--- a/shared/db/Group.ts
+++ b/shared/db/Group.ts
@@ -8,6 +8,7 @@ export type Group = Audit & {
   id: string
   name: string
   mfaRequired: boolean | number
+  autoAssign: boolean | number
 }
 
 export type UserGroup = Audit & {


### PR DESCRIPTION
## Description

- Allow Groups to be Auto Assigned to Invitations.
- Groups with the Auto Assign checkbox checked will be added automatically to new invites.
- More explicit sqlite connection config, hopefully guards against future changes to sqlite behavior in knex.

## Related Tickets & Documents
#359 

## Screenshots
<img width="280" src="https://github.com/user-attachments/assets/beffe639-83c5-424d-ba4d-e9d668b78d96" />
<img width="280" src="https://github.com/user-attachments/assets/1042cb5c-ac1f-4d28-a260-f298b58ddcfc" />

