### PR TITLE
Fix Default Redirect Overriding Existing Redirect on Email Verification

### DIFF
--- a/frontend/src/app/pages/login/login.component.ts
+++ b/frontend/src/app/pages/login/login.component.ts
@@ -88,7 +88,7 @@ export class LoginComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       } catch (_e) {
         // interaction is missing, could not log in without it
-        await this.authService.createInteraction()
+        await this.authService.createInteraction(false)
         try {
           await this.authService.interactionExists()
         } catch (e) {

--- a/frontend/src/app/pages/registration/registration.component.ts
+++ b/frontend/src/app/pages/registration/registration.component.ts
@@ -84,7 +84,7 @@ export class RegistrationComponent implements OnInit {
         }
       } catch (_e) {
         // interaction session is missing, could not log in without it
-        await this.authService.createInteraction()
+        await this.authService.createInteraction(true)
       } finally {
         this.spinnerService.hide()
       }

--- a/frontend/src/app/pages/verify-email/verify/verify.component.ts
+++ b/frontend/src/app/pages/verify-email/verify/verify.component.ts
@@ -43,9 +43,21 @@ export class VerifyComponent implements OnInit {
       this.spinnerService.show()
 
       try {
-        await this.authService.interactionExists()
+        const info = await this.authService.interactionExists()
+        if (info.successRedirect) {
+          window.location.assign(info.successRedirect.location)
+        }
       } catch (_e) {
+        // interaction is missing, could not continue without it
         await this.authService.createInteraction()
+        try {
+          await this.authService.interactionExists()
+        } catch (e) {
+          // attempted to create interaction and failed
+          console.error('Interaction cookie session not set even after creating one.')
+          console.error(e)
+          this.snackbarService.error('Could not create session.')
+        }
       }
 
       this.config = await this.configService.getConfig()

--- a/frontend/src/app/pages/verify-email/verify/verify.component.ts
+++ b/frontend/src/app/pages/verify-email/verify/verify.component.ts
@@ -43,13 +43,10 @@ export class VerifyComponent implements OnInit {
       this.spinnerService.show()
 
       try {
-        const info = await this.authService.interactionExists()
-        if (info.successRedirect) {
-          window.location.assign(info.successRedirect.location)
-        }
+        await this.authService.interactionExists()
       } catch (_e) {
         // interaction is missing, could not continue without it
-        await this.authService.createInteraction()
+        await this.authService.createInteraction(true)
         try {
           await this.authService.interactionExists()
         } catch (e) {

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -30,9 +30,9 @@ export class AuthService {
     return firstValueFrom(this.http.get<InteractionInfo>('/api/interaction/exists'))
   }
 
-  async createInteraction() {
+  async createInteraction(defaultRedir: boolean = false) {
     try {
-      await firstValueFrom(this.http.get<null>(oidcLoginPath(getCurrentHost(), 'login'), {
+      await firstValueFrom(this.http.get<null>(oidcLoginPath(getCurrentHost(), defaultRedir, 'login'), {
         redirect: 'manual',
       }))
     } catch (e) {

--- a/server/cli/server.ts
+++ b/server/cli/server.ts
@@ -125,7 +125,7 @@ export async function serve() {
           logger({
             level: 'error',
             message: 'Error occurred during transaction commit/rollback',
-            error: error instanceof Error ? error : { message: String(error) },
+            errors: error instanceof Error ? [error] : [{ message: String(error) }],
           })
         } finally {
           purgeAsyncLog()
@@ -238,14 +238,14 @@ export async function serve() {
   })
 
   // Last chance error handler
-  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
     logger({
       level: 'error',
       message: 'Unhandled API error',
-      error: err,
+      errors: err instanceof Error ? [err] : [{ message: String(err) }],
     })
     if (!res.statusCode || res.statusCode === 200) {
-      const errStatus = 'status' in err && typeof err.status === 'number' ? err.status : 500
+      const errStatus = err && typeof err === 'object' && 'status' in err && typeof err.status === 'number' ? err.status : 500
       res.status(errStatus)
     }
     if (res.headersSent) {
@@ -340,7 +340,7 @@ export async function serve() {
         logger({
           level: 'error',
           message: 'Error occurred during table maintenance',
-          error: e instanceof Error ? e : { message: String(e) },
+          errors: e instanceof Error ? [e] : [{ message: String(e) }],
         })
       } finally {
         purgeAsyncLog()
@@ -353,7 +353,7 @@ export async function serve() {
         logger({
           level: 'error',
           message: 'Error occurred while sending admin notifications',
-          error: e instanceof Error ? e : { message: String(e) },
+          errors: e instanceof Error ? [e] : [{ message: String(e) }],
         })
       } finally {
         purgeAsyncLog()

--- a/server/db/connection.ts
+++ b/server/db/connection.ts
@@ -41,10 +41,10 @@ async function runSchemaUpdates(connectionOptions: Knex.Config) {
     const violations = await db.raw<unknown[]>('PRAGMA foreign_key_check')
     if (violations.length) {
       logger({ level: 'error', message: 'foreign_key_check constraint violations detected in database!',
-        error: {
-          name: 'Foreign Key Check Violation',
+        errors: [{
+          name: 'ForeignKeyCheckViolation',
           message: 'foreign_key_check constraint violations detected in database!',
-        },
+        }],
       })
     }
     console.log(violations)

--- a/server/db/tableMaintenance.ts
+++ b/server/db/tableMaintenance.ts
@@ -48,7 +48,7 @@ export async function updateEncryptedTables(enableWarnings: boolean = false) {
     logger({
       level: 'error',
       message: 'WARNING!!!'
-        + ' You have key(s) that could not be decrypted with the provided STORAGE_KEY or STORAGE_KEY_SECONDARY.'
+        + ' There are keys that could not be decrypted with the provided STORAGE_KEY or STORAGE_KEY_SECONDARY.'
         + ' This could be due to a mistake while rotating the storage key.'
         + ' New keys were generated to replace them, this invalidated all sessions and tokens.'
         + ' If you still have your original STORAGE_KEY, you can set it as the STORAGE_KEY_SECONDARY and get your keys back.',
@@ -78,7 +78,7 @@ export async function updateEncryptedTables(enableWarnings: boolean = false) {
     logger({
       level: 'error',
       message: 'WARNING!!!'
-        + ' You have OIDC Apps that could not be decrypted with the provided STORAGE_KEY or STORAGE_KEY_SECONDARY.'
+        + ' There are OIDC Apps that could not be decrypted with the provided STORAGE_KEY or STORAGE_KEY_SECONDARY.'
         + ' This could be due to a mistake while rotating the storage key.'
         + ' If you still have your original STORAGE_KEY, you can set it as the STORAGE_KEY_SECONDARY to recover them.'
         + ' Non-decryptable Clients: ' + lockedClients.map(c => c.id).join(', '),
@@ -98,9 +98,10 @@ export async function updateEncryptedTables(enableWarnings: boolean = false) {
     logger({
       level: 'error',
       message: 'WARNING!!!'
-        + ' You have MFA TOTP codes that could not be decrypted with the provided STORAGE_KEY or STORAGE_KEY_SECONDARY.'
+        + ' There are MFA TOTP codes that could not be decrypted with the provided STORAGE_KEY or STORAGE_KEY_SECONDARY.'
         + ' This could be due to a mistake while rotating the storage key.'
-        + ' If you still have your original STORAGE_KEY, you can set it as the STORAGE_KEY_SECONDARY to recover them.',
+        + ' If you still have your original STORAGE_KEY, you can set it as the STORAGE_KEY_SECONDARY to recover them.'
+        + ' MFA enabled users may have reduced security until this is fixed!',
     })
   }
 

--- a/server/db/util.ts
+++ b/server/db/util.ts
@@ -42,6 +42,9 @@ export function decryptString(input: string, storageKeys: (string | undefined)[]
       logger({
         level: 'error',
         message: 'Encrypted metadata is missing required properties.',
+        errors: [{
+          message: 'An encrypted value in the database is improperly formatted.',
+        }],
       })
       return null
     }
@@ -67,6 +70,9 @@ export function decryptString(input: string, storageKeys: (string | undefined)[]
     logger({
       level: 'error',
       message: 'Encrypted value storage algorithm not recognized.',
+      errors: [{
+        message: 'An encrypted value in the database is using an encryption scheme that is not recognized.',
+      }],
     })
     return null
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -45,7 +45,7 @@ export const argv = yargs(hideBin(process.argv))
       logger({
         level: 'error',
         message: 'Server failed to start',
-        error: e instanceof Error ? e : { message: String(e) },
+        errors: e instanceof Error ? [e] : [{ message: String(e) }],
       })
       exit(1)
     }
@@ -63,7 +63,7 @@ export const argv = yargs(hideBin(process.argv))
         logger({
           level: 'error',
           message: 'Database migration failed',
-          error: e instanceof Error ? e : { message: String(e) },
+          errors: e instanceof Error ? [e] : [{ message: String(e) }],
         })
         exit(1)
       }
@@ -95,7 +95,7 @@ export const argv = yargs(hideBin(process.argv))
         logger({
           level: 'error',
           message: 'Failed to generate password reset link',
-          error: e instanceof Error ? e : { message: String(e) },
+          errors: e instanceof Error ? [e] : [{ message: String(e) }],
         })
         exit(1)
       }

--- a/server/oidc/adapter.ts
+++ b/server/oidc/adapter.ts
@@ -74,7 +74,9 @@ export class KnexAdapter implements Adapter {
           level: 'error',
           message: 'Error occurred while parsing OIDC payload.',
           // do not leak error details, may contain secrets
-          error: e instanceof Error ? { name: e.name } : { message: 'Error parsing OIDC payload' },
+          errors: e instanceof Error
+            ? [{ name: e.name, message: 'Error parsing OIDC payload' }]
+            : [{ message: 'Error parsing OIDC payload' }],
         })
         throw e
       }

--- a/server/oidc/provider.ts
+++ b/server/oidc/provider.ts
@@ -204,14 +204,15 @@ consentPromptPolicy.checks.add(new Check('proxyauth_url_invalid',
         errorMessage = 'proxyauth_internal_client but no proxyauth domain matches proxyauth redirect url.'
       }
       if (errorMessage) {
-        logger({ level: 'error', message: 'proxyauth_internal_client validation failed.', error: {
+        logger({ level: 'debug', message: 'proxyauth_internal_client validation failed.', error: {
+          name: 'ProxyAuthURLInvalid',
           message: errorMessage + ` redirect_url = ${String(oidc.params?.redirect_uri)}`,
         } })
         // Throw oidc error
         const error: errors.OIDCProviderError = {
           statusCode: 400,
           error: 'proxyauth_url_invalid',
-          error_description: errorMessage,
+          error_description: errorMessage + ` redirect_url = ${String(oidc.params?.redirect_uri)}`,
           allow_redirect: false,
           status: 400,
           expose: true,

--- a/server/oidc/provider.ts
+++ b/server/oidc/provider.ts
@@ -204,10 +204,10 @@ consentPromptPolicy.checks.add(new Check('proxyauth_url_invalid',
         errorMessage = 'proxyauth_internal_client but no proxyauth domain matches proxyauth redirect url.'
       }
       if (errorMessage) {
-        logger({ level: 'debug', message: 'proxyauth_internal_client validation failed.', error: {
+        logger({ level: 'debug', message: 'proxyauth_internal_client validation failed.', errors: [{
           name: 'ProxyAuthURLInvalid',
           message: errorMessage + ` redirect_url = ${String(oidc.params?.redirect_uri)}`,
-        } })
+        }] })
         // Throw oidc error
         const error: errors.OIDCProviderError = {
           statusCode: 400,

--- a/server/oidc/provider.ts
+++ b/server/oidc/provider.ts
@@ -17,6 +17,7 @@ import type { IncomingMessage, ServerResponse } from 'http'
 import { getProxyAuthWithCache } from '../db/proxyAuth'
 import { RESPONSE_TYPES } from '@shared/api-request/admin/ClientUpsert'
 import { randomBytes } from 'crypto'
+import { logger } from '../util/logger'
 
 // Extend 'oidc-provider' where needed
 declare module 'oidc-provider' {
@@ -203,6 +204,9 @@ consentPromptPolicy.checks.add(new Check('proxyauth_url_invalid',
         errorMessage = 'proxyauth_internal_client but no proxyauth domain matches proxyauth redirect url.'
       }
       if (errorMessage) {
+        logger({ level: 'error', message: 'proxyauth_internal_client validation failed.', error: {
+          message: errorMessage + ` redirect_url = ${String(oidc.params?.redirect_uri)}`,
+        } })
         // Throw oidc error
         const error: errors.OIDCProviderError = {
           statusCode: 400,

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -374,7 +374,7 @@ adminRouter.patch('/user',
           logger({
             level: 'error',
             message: 'Error occurred while sending approved email.',
-            error: e instanceof Error ? e : { message: String(e) },
+            errors: e instanceof Error ? [e] : [{ message: String(e) }],
           })
         }
       }
@@ -466,7 +466,7 @@ adminRouter.patch('/users/approve',
           logger({
             level: 'error',
             message: 'Error occurred while sending approved email.',
-            error: e instanceof Error ? e : { message: String(e) },
+            errors: e instanceof Error ? [e] : [{ message: String(e) }],
           })
         }
       }

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -83,13 +83,14 @@ router.get('/authz/auth-request', async (req: Request, res) => {
 router.get('/cb',
   zodValidate({
     query: {
+      defaultRedir: zod.stringbool().optional(),
       error: zod.string().optional(),
       error_description: zod.string().optional(),
       iss: zod.string().optional(),
     },
   }),
   (req, res) => {
-    const { error } = req.query
+    const { error, defaultRedir } = req.query
     if (error) {
       res.status(500).send({
         message: 'Error occurred during authentication.',
@@ -97,7 +98,9 @@ router.get('/cb',
       return
     }
 
-    res.redirect(appConfig.APP_URL)
+    const redir = defaultRedir && appConfig.DEFAULT_REDIRECT ? appConfig.DEFAULT_REDIRECT : appConfig.APP_URL
+
+    res.redirect(redir)
     return
   })
 

--- a/server/routes/api.ts
+++ b/server/routes/api.ts
@@ -59,6 +59,9 @@ router.get('/authz/forward-auth', async (req: Request, res) => {
     logger({
       level: 'error',
       message: 'Invalid x-forwarded headers in ProxyAuth Domain request.',
+      errors: [{
+        message: 'X-Forwarded-* headers in a ProxyAuth Domain request were not properly set.',
+      }],
     })
     res.sendStatus(400)
     return
@@ -72,7 +75,10 @@ router.get('/authz/auth-request', async (req: Request, res) => {
   if (!url) {
     logger({
       level: 'error',
-      message: 'Invalid x-original-url header in ProxyAuth Domain request.',
+      message: 'Invalid X-Original-Url header in ProxyAuth Domain request.',
+      errors: [{
+        message: 'X-Original-Url header in a ProxyAuth Domain request was not properly set.',
+      }],
     })
     res.sendStatus(400)
     return
@@ -127,6 +133,9 @@ router.get('/proxyauth_cb',
       logger({
         level: 'error',
         message: 'Invalid proxyauth_url query parameter in ProxyAuth callback.',
+        errors: [{
+          message: 'An invalid proxyauth_url parameter was provided to the proxy auth callback endpoint.',
+        }],
       })
       res.status(400).send({ message: 'Invalid proxyauth_url query parameter in ProxyAuth callback.' })
       return

--- a/server/routes/interaction.ts
+++ b/server/routes/interaction.ts
@@ -393,13 +393,6 @@ router.post('/register',
       }
 
       await db().table<Invitation>(TABLES.INVITATION).delete().where({ id: invitation.id })
-
-      // Accepted Invitation should redirect to DEFAULT_REDIRECT if set
-      const defaultRedirect = appConfig.DEFAULT_REDIRECT
-      if (defaultRedirect) {
-        interaction.params.redirect_uri = defaultRedirect
-        await interaction.save(TTLs.INTERACTION)
-      }
     }
 
     const createdUser = await getUserById(user.id)
@@ -544,13 +537,6 @@ router.post('/register/passkey/end',
       }
 
       await db().table<Invitation>(TABLES.INVITATION).delete().where({ id: invitation.id })
-
-      // Accepted Invitation should redirect to DEFAULT_REDIRECT if set
-      const defaultRedirect = appConfig.DEFAULT_REDIRECT
-      if (defaultRedirect) {
-        interaction.params.redirect_uri = defaultRedirect
-        await interaction.save(TTLs.INTERACTION)
-      }
     }
 
     const createdUser = await getUserById(user.id)
@@ -932,13 +918,6 @@ router.post('/verify_email',
       email: emailVerification.email,
     })
     await db().delete().table<EmailVerification>(TABLES.EMAIL_VERIFICATION).where(emailVerification)
-
-    // Email verification should redirect to DEFAULT_REDIRECT if set
-    const defaultRedirect = appConfig.DEFAULT_REDIRECT
-    if (defaultRedirect && interaction) {
-      interaction.params.redirect_uri = defaultRedirect
-      await interaction.save(TTLs.INTERACTION)
-    }
 
     const redir = await loginResult(req, res, {
       userId: user.id,

--- a/server/routes/interaction.ts
+++ b/server/routes/interaction.ts
@@ -85,7 +85,7 @@ router.get('/', async (req, res) => {
         prompt: prompt.name,
         reasons: prompt.reasons,
         client_id: params.client_id,
-        proxyauth: params.client_id === 'proxyauth_internal_client',
+        redirect_uri: params.redirect_uri,
       },
     },
   })

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -81,7 +81,7 @@ publicRouter.post('/send_password_reset',
       logger({
         level: 'error',
         message: 'Error occurred while sending password reset email.',
-        error: e instanceof Error ? e : { message: String(e) },
+        errors: e instanceof Error ? [e] : [{ message: String(e) }],
       })
     }
 

--- a/server/util/config.ts
+++ b/server/util/config.ts
@@ -393,7 +393,7 @@ appConfig.APP_URL = appConfig.APP_URL.replace(/\/+$/, '')
 if (!appConfig.APP_URL || !URL.parse(appConfig.APP_URL)) {
   logger({
     level: 'error',
-    message: 'APP_URL must be set and be a valid URL, starting with http(s)://',
+    message: 'APP_URL must be set and be a valid URL starting with http(s)://',
   })
   exit(1)
 }
@@ -482,11 +482,11 @@ export function getSessionDomain() {
 }
 
 export function sessionDomainReaches(hostName: string) {
-  const targetDomain = getBaseDomain(hostName)
-  const sessionDomain = getSessionDomain()
+  const targetDomain = getBaseDomain(hostName) || hostName
+  const sessionDomain = getSessionDomain() || appUrl().hostname
   // Add dot to start of sessionDomain if it doesn't already have one, to prevent false positives
-  const dotSD = sessionDomain && !sessionDomain.startsWith('.') ? '.' + sessionDomain : sessionDomain
-  return targetDomain === sessionDomain || !dotSD || hostName.endsWith(dotSD)
+  const dotSD = !sessionDomain.startsWith('.') ? '.' + sessionDomain : sessionDomain
+  return targetDomain === sessionDomain || hostName.endsWith(dotSD)
 }
 
 //

--- a/server/util/config.ts
+++ b/server/util/config.ts
@@ -300,7 +300,7 @@ function registerClientVariable(clients: Map<string, ClientResponse>,
           value,
         },
       },
-      error: e instanceof Error ? e : { message: String(e) },
+      errors: e instanceof Error ? [e] : [{ message: String(e) }],
     })
   }
 }

--- a/server/util/email.ts
+++ b/server/util/email.ts
@@ -45,7 +45,7 @@ if (appConfig.SMTP_HOST) {
     logger({
       level: 'error',
       message: 'SMTP email connection failed',
-      error: e instanceof Error ? e : { message: String(e) },
+      errors: e instanceof Error ? [e] : [{ message: String(e) }],
     })
   })
 } else {

--- a/server/util/logger.ts
+++ b/server/util/logger.ts
@@ -2,7 +2,7 @@ import { booleanString } from './util'
 import { als } from './als'
 
 export type LogShape = {
-  // debug logs are only printed when ENABLE_DEBUG is true, and do not include stack traces
+  // debug logs are only printed when ENABLE_DEBUG is true
   // error logs are reserved for configuration or runtime errors, and always printed
   level: 'debug' | 'info' | 'error'
   timestamp?: number
@@ -34,7 +34,6 @@ export type LogShape = {
   error?: {
     name?: string
     message?: string
-    stack?: string
   }
 }
 
@@ -68,7 +67,7 @@ export function logger(log: LogShape) {
       : lowerLog.timestamp || higherLog.timestamp
 
     const error = higherLog.error
-      ? { name: higherLog.error.name, message: higherLog.error.message, stack: higherLog.error.stack }
+      ? { name: higherLog.error.name, message: higherLog.error.message }
       : undefined
 
     store.log = {
@@ -76,7 +75,7 @@ export function logger(log: LogShape) {
       // earlier timestamp takes precedence
       timestamp: earlierTimestamp,
       details: lowerLog.details || higherLog.details ? { ...lowerLog.details, ...higherLog.details } : undefined,
-      // error and stack should be taken from the log with the higher level, and if they do not exist should be unset
+      // error should be taken from the log with the higher level, and if they do not exist should be unset
       error,
     }
   }
@@ -102,13 +101,7 @@ function printLog(log: LogShape) {
       console.log(format(log))
       break
     case 'error':
-      // Only print the stack trace when ENABLE_DEBUG is enabled
-      if (!booleanString(process.env.ENABLE_DEBUG)) {
-        const { error, ...rest } = log
-        console.error(format({ ...rest, error: error ? { name: error.name, message: error.message } : undefined }))
-      } else {
-        console.error(format(log))
-      }
+      console.error(format(log))
       break
   }
 }

--- a/server/util/logger.ts
+++ b/server/util/logger.ts
@@ -31,15 +31,24 @@ export type LogShape = {
       amr: string[]
     }
   }
-  error?: {
+  errors?: {
     name?: string
     message?: string
-  }
+  }[]
 }
 
 export function logger(log: LogShape) {
   if (!log.timestamp) {
     log = { timestamp: Date.now(), ...log }
+  }
+
+  if (log.errors) {
+    log.errors = log.errors.map((e) => {
+      return {
+        name: e.name,
+        message: e.message,
+      }
+    })
   }
 
   // Store the log in the ALS context if it exists
@@ -66,9 +75,7 @@ export function logger(log: LogShape) {
       ? Math.min(higherLog.timestamp, lowerLog.timestamp)
       : lowerLog.timestamp || higherLog.timestamp
 
-    const error = higherLog.error
-      ? { name: higherLog.error.name, message: higherLog.error.message }
-      : undefined
+    const error = higherLog.errors && lowerLog.errors ? higherLog.errors.concat(lowerLog.errors) : higherLog.errors || lowerLog.errors
 
     store.log = {
       ...lowerLog, ...higherLog,
@@ -76,7 +83,7 @@ export function logger(log: LogShape) {
       timestamp: earlierTimestamp,
       details: lowerLog.details || higherLog.details ? { ...lowerLog.details, ...higherLog.details } : undefined,
       // error should be taken from the log with the higher level, and if they do not exist should be unset
-      error,
+      errors: error,
     }
   }
   return log // do not print the log immediately, it will be printed when purgeAsyncLog is called

--- a/server/util/theme.ts
+++ b/server/util/theme.ts
@@ -58,7 +58,7 @@ export async function generateTheme() {
     logger({
       level: 'error',
       message: 'Error occurred while generating theme.',
-      error: error instanceof Error ? error : { message: String(error) },
+      errors: error instanceof Error ? [error] : [{ message: String(error) }],
     })
   }
 }

--- a/shared/oidc.ts
+++ b/shared/oidc.ts
@@ -1,8 +1,9 @@
 export function oidcLoginPath(
   baseUrl: string,
+  defaultRedir: boolean = false,
   prompt?: 'login' | 'consent',
 ) {
-  const redirectParam = `redirect_uri=${encodeURIComponent(baseUrl + `/api/cb`)}`
+  const redirectParam = `redirect_uri=${encodeURIComponent(baseUrl + `/api/cb${defaultRedir ? '?defaultRedir=true' : ''}`)}`
   let queryParams = `client_id=auth_internal_client&response_type=none&scope=openid&${redirectParam}`
   queryParams += prompt ? `&prompt=${prompt}` : ''
   return `/oidc/auth?${queryParams}`


### PR DESCRIPTION
## Description

- Fix issue where email validation would always redirect to DEFAULT_REDIRECT if it was set on success, even when a perfectly valid redirect was already available.
- Added additional logging when an interaction session cookie is needed and cannot be set.
- Added additional logging when proxyauth internal client validation fails.
- Remove stack traces from debug logging, this won't be useful except in development.
