### PR TITLE
Updated Loading Spinner Logic so It Does Not Always Show

### DIFF
--- a/frontend/src/app/services/spinner.service.ts
+++ b/frontend/src/app/services/spinner.service.ts
@@ -11,20 +11,26 @@ export class SpinnerService {
 
   show() {
     this.count++
-    this.checkStatus()
+    setTimeout(() => {
+      this.checkStatusShow()
+    }, 500) // Do not show the spinner if the operation is very fast
   }
 
   hide() {
+    this.count--
     setTimeout(() => {
-      this.count--
-      this.checkStatus()
-    }, 500)
+      this.checkStatusHide()
+    }, 2000) // Keep the spinner visible for a bit to avoid flickering
   }
 
-  private checkStatus() {
+  private checkStatusShow() {
     if (this.count > 0) {
       void this.ngxSpinnerService.show()
-    } else {
+    }
+  }
+
+  private checkStatusHide() {
+    if (this.count <= 0) {
       void this.ngxSpinnerService.hide()
     }
   }


### PR DESCRIPTION
## Description
Updated Loading Spinner Logic to Not Always Show.
Spinner will not show if an action is faster than 500ms, and will show for at least two seconds if it shows at all.

## Related Tickets & Documents
#379
