### PR TITLE
Implement LDAP server functionality

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -2,3 +2,10 @@ APP_URL="http://localhost:3000"
 STORAGE_KEY=
 DB_HOST="voidauth-db"
 DB_PASSWORD=
+
+# Optional LDAP server
+LDAP_ENABLED=false
+LDAP_PORT=3890
+LDAP_BASE_DN="dc=voidauth"
+LDAP_BIND_DN="cn=ldap_bind,dc=voidauth"
+LDAP_BIND_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ USER 0:0
 VOLUME ["/app/config"]
 VOLUME ["/app/db"]
 EXPOSE 3000
+EXPOSE 3890
 ENTRYPOINT [ "node", "./dist/index.mjs" ]
 
 HEALTHCHECK CMD ["node", "-e", "\"fetch('http://localhost:'+(process.env.APP_PORT||3000)+'/healthcheck').then(r=>process.exit(r.status===200?0:1)).catch(e=>process.exit(1))\""]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ VoidAuth is an open-source SSO authentication and user management provider that 
 Features:
 
 - 🌐 OpenID Connect (OIDC) Provider
+- 📖 LDAP Directory Server
 - 🔄 Proxy ForwardAuth
 - 👤 User and Groups Management
 - 📨 User Self-Registration and Invitations

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -19,6 +19,7 @@ services:
       # - /var/run/docker.sock:/var/run/docker.sock:ro
     ports:
       - "3000:3000" # may not be needed, depending on reverse-proxy setup
+      # - "3890:3890" # only needed if LDAP Server is enabled
     environment:
       # Required environment variables, set in .env file or replace ${...} with value
       # See https://voidauth.app/#/Getting-Started?id=environment-variables for a list of possible environment variables
@@ -59,6 +60,7 @@ services:
       # - /var/run/docker.sock:/var/run/docker.sock:ro
     ports:
       - "3000:3000" # may not be needed, depending on reverse-proxy setup
+      # - "3890:3890" # only needed if LDAP Server is enabled
     environment:
       # Required environment variables, set in .env file or replace ${...} with value
       # See https://voidauth.app/#/Getting-Started?id=environment-variables for a list of possible environment variables
@@ -169,6 +171,23 @@ All of these settings are ✅ recommended to be set to the correct values for yo
 | SMTP_TLS_CIPHERS | | TLS cipher to use, only set if required by your SMTP provider |
 | SMTP_TLS_MIN_VERSION | | Minimum TLS version, only set if required by your SMTP provider. Possible values are `TLSv1.3`, `TLSv1.2`, `TLSv1.1`, `TLSv1` |
 
+#### LDAP Settings
+LDAP is disabled by default. See the [LDAP Server](LDAP-Server.md) guide for setup details and client examples.
+
+| Name | Default | Description | Required | Recommended |
+| :------ | :-- | :-------- | :--- | :--- |
+| LDAP_ENABLED | `false` | Enables the read-only LDAP server. | | |
+| LDAP_HOST | `0.0.0.0` | Address the LDAP server listens on. | | |
+| LDAP_PORT | `3890` | Port the LDAP server listens on. | | |
+| LDAP_BASE_DN | `dc=voidauth` | Base distinguished name for LDAP directory entries. | | ✅ if LDAP is enabled |
+| LDAP_USERS_OU | `people` | Organizational unit used for user entries. | | |
+| LDAP_GROUPS_OU | `groups` | Organizational unit used for group entries. | | |
+| LDAP_BIND_DN | `cn=ldap_bind,dc=voidauth` | Service account DN LDAP clients can bind as before searching. | | ✅ if LDAP is enabled |
+| LDAP_BIND_PASSWORD | | Password for the LDAP service account bind DN. | | ✅ if LDAP is enabled |
+| LDAP_ALLOW_ANONYMOUS_SEARCH | `false` | Allows anonymous LDAP clients to search the directory. | | |
+| LDAP_TLS_CERT_FILE | | Path to a PEM certificate file. If set, `LDAP_TLS_KEY_FILE` must also be set and VoidAuth listens with LDAPS. | | |
+| LDAP_TLS_KEY_FILE | | Path to the PEM private key file for `LDAP_TLS_CERT_FILE`. | | |
+
 #### Misc.
 | Name | Default | Description | Required | Recommended |
 | :------ | :-- | :-------- | :--- | :--- |
@@ -198,4 +217,3 @@ For information on how to change the email templates used for invitations, passw
 
 ### Multi-Domain Protection
 You can secure multiple domains you own by running multiple instances of VoidAuth using the same database. They should have the same **STORAGE_KEY** and **DB_\*** variables, but may otherwise have completely different configurations. The **APP_URL** variables of each would cover a different domain. If the domains you were trying to secure were `example.com` and `your-domain.net` you might set the **APP_URL** variables like `https://auth.example.com` and `https://id.your-domain.net`. These two instances would share everything in the shared DB, including users, OIDC Apps, ProxyAuth Domains, etc.
-

--- a/docs/LDAP-Server.md
+++ b/docs/LDAP-Server.md
@@ -1,0 +1,114 @@
+# LDAP Server
+
+VoidAuth can expose a read-only LDAP directory for services that need LDAP for authentication, user lookup, or group lookup.
+
+The LDAP directory is backed by VoidAuth users and security groups:
+
+* Users are exposed under `ou=people,{LDAP_BASE_DN}`
+* Groups are exposed under `ou=groups,{LDAP_BASE_DN}`
+* User entries use `inetOrgPerson` and `posixAccount`
+* Group entries use `groupOfNames`, `groupOfUniqueNames`, and `posixGroup`
+* LDAP bind authentication uses the user's VoidAuth password
+
+> [!IMPORTANT]
+> LDAP support is read-only. Users, passwords, and groups must still be managed in VoidAuth.
+
+## Configuration
+
+LDAP is disabled by default. To enable it, add the LDAP environment variables to the VoidAuth service:
+
+```yaml
+services:
+  voidauth:
+    image: voidauth/voidauth:latest
+    ports:
+      - "3000:3000"
+      - "3890:3890"
+    environment:
+      APP_URL: https://auth.example.com
+      STORAGE_KEY: ${STORAGE_KEY}
+      DB_HOST: voidauth-db
+      DB_PASSWORD: ${DB_PASSWORD}
+
+      LDAP_ENABLED: "true"
+      LDAP_PORT: 3890
+      LDAP_BASE_DN: dc=example,dc=com
+      LDAP_BIND_DN: cn=ldap_bind,dc=example,dc=com
+      LDAP_BIND_PASSWORD: ${LDAP_BIND_PASSWORD}
+```
+
+### Environment Variables
+
+| Name | Default | Description |
+| :------ | :-- | :-------- |
+| LDAP_ENABLED | `false` | Enables the LDAP server. |
+| LDAP_HOST | `0.0.0.0` | Address the LDAP server listens on. |
+| LDAP_PORT | `3890` | Port the LDAP server listens on. |
+| LDAP_BASE_DN | `dc=voidauth` | Base distinguished name for the directory. |
+| LDAP_USERS_OU | `people` | Organizational unit used for user entries. |
+| LDAP_GROUPS_OU | `groups` | Organizational unit used for group entries. |
+| LDAP_BIND_DN | `cn=ldap_bind,dc=voidauth` | Service account DN that LDAP clients can bind with before searching. |
+| LDAP_BIND_PASSWORD | | Password for `LDAP_BIND_DN`. Recommended for most clients. |
+| LDAP_ALLOW_ANONYMOUS_SEARCH | `false` | Allows anonymous LDAP clients to search the directory. |
+| LDAP_TLS_CERT_FILE | | Path to a PEM certificate file. If set, `LDAP_TLS_KEY_FILE` must also be set and VoidAuth listens with LDAPS. |
+| LDAP_TLS_KEY_FILE | | Path to the PEM private key file for `LDAP_TLS_CERT_FILE`. |
+
+> [!WARNING]
+> Plain LDAP sends bind passwords over the network without encryption. Use this only on a trusted private network, or enable LDAPS with `LDAP_TLS_CERT_FILE` and `LDAP_TLS_KEY_FILE`.
+
+## Directory Layout
+
+If `LDAP_BASE_DN` is `dc=example,dc=com`, a user named `alice` is exposed as:
+
+```text
+uid=alice,ou=people,dc=example,dc=com
+```
+
+A group named `admins` is exposed as:
+
+```text
+cn=admins,ou=groups,dc=example,dc=com
+```
+
+Common user attributes:
+
+| Attribute | Value |
+| :------ | :-- |
+| uid | VoidAuth username |
+| cn | VoidAuth display name, or username |
+| displayName | VoidAuth display name, or username |
+| mail | VoidAuth email address |
+| entryUUID | VoidAuth user id |
+| memberOf | Group DNs for the user's VoidAuth security groups |
+
+Common group attributes:
+
+| Attribute | Value |
+| :------ | :-- |
+| cn | VoidAuth security group name |
+| entryUUID | VoidAuth group id |
+| member | User DNs for users in the group |
+| uniqueMember | Same values as `member` |
+| memberUid | Usernames for users in the group |
+
+Users that are unapproved, expired, or missing required email verification are not returned in LDAP search results. Users can bind only if they have a VoidAuth password and can log in with a password alone. If a user or one of their groups requires MFA, LDAP simple bind is denied because LDAP simple bind cannot complete a second factor.
+
+## Client Setup
+
+Most clients should use these values:
+
+| Client Setting | Value |
+| :------ | :-- |
+| URL | `ldap://voidauth:3890` or `ldaps://voidauth:3890` |
+| Base DN | `LDAP_BASE_DN` |
+| Bind DN | `LDAP_BIND_DN` |
+| Bind Password | `LDAP_BIND_PASSWORD` |
+| User Base DN | `ou=people,{LDAP_BASE_DN}` |
+| Group Base DN | `ou=groups,{LDAP_BASE_DN}` |
+| Login Filter | `(&(objectClass=inetOrgPerson)(mail=?))` or `(&(objectClass=inetOrgPerson)(uid=?))` |
+| Group Filter | `(&(objectClass=groupOfNames)(member=?))` |
+| Email Attribute | `mail` |
+| Username Attribute | `uid` |
+| Group Attribute | `memberOf` |
+
+For services such as Stalwart that support LDAP bind authentication, enable bind authentication and do not configure password-hash comparison. VoidAuth does not expose `userPassword` hashes over LDAP.

--- a/docs/Security-Groups.md
+++ b/docs/Security-Groups.md
@@ -21,6 +21,11 @@ Security Group settings also includes additional options:
 
 Security Groups are used in both OIDC Apps and ProxyAuth Domains.
 
+### LDAP
+Security Groups are also exposed through the optional [LDAP Server](LDAP-Server.md):
+* User entries include group DNs in the `memberOf` attribute
+* Group entries include user DNs in the `member` and `uniqueMember` attributes
+
 ### ProxyAuth
 Security Groups are used in ProxyAuth Domains for:
 * ProxyAuth Domain authorization

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -4,6 +4,7 @@
 - Admin Guides
   * [OIDC App Setup](OIDC-Setup.md)
   * [OIDC App Guides](OIDC-Guides.md)
+  * [LDAP Server](LDAP-Server.md)
   * [ProxyAuth](ProxyAuth-and-Trusted-Header-SSO-Setup.md)
   * [User Management](User-Management.md)
   * [Security Groups](Security-Groups.md)

--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -65,6 +65,7 @@ await esbuild.build({
     'tedious',
     'oracledb',
     'cpu-features',
+    '*.node',
   ]),
 }).catch(() => process.exit(1))
 

--- a/server/cli/server.ts
+++ b/server/cli/server.ts
@@ -18,6 +18,7 @@ import { createInitialAdmin } from '../db/user'
 import { logger, purgeAsyncLog } from '../util/logger'
 import { sensitiveRateLimit, standardRateLimit } from '../util/rateLimit'
 import { FORBIDDEN_PATHS, NOT_FOUND_PATHS } from '@shared/constants'
+import { startLDAPServer } from '../ldap/server'
 
 const PROCESS_ROOT = path.dirname(process.argv[1] ?? '.')
 const FE_ROOT = path.join(PROCESS_ROOT, '../frontend/dist/browser')
@@ -25,6 +26,7 @@ const FE_ROOT = path.join(PROCESS_ROOT, '../frontend/dist/browser')
 export async function serve() {
   // Do not wait for theme to generate before starting
   void generateTheme()
+  startLDAPServer()
 
   const app = express()
 

--- a/server/ldap/directory.ts
+++ b/server/ldap/directory.ts
@@ -1,0 +1,370 @@
+import { createHash } from 'node:crypto'
+import { db } from '../db/db'
+import type { User } from '@shared/db/User'
+import type { Group, UserGroup } from '@shared/db/Group'
+import { TABLES } from '@shared/db'
+import appConfig from '../util/config'
+import { ADMIN_GROUP } from '@shared/constants'
+import { isExpired, isUnapproved, isUnverifiedEmail } from '@shared/user'
+
+export type LDAPAttributes = Record<string, string | string[]>
+
+export type LDAPEntry = {
+  dn: string
+  attributes: LDAPAttributes
+}
+
+export type LDAPSearchScope = 'base' | 'one' | 'sub' | 0 | 1 | 2
+
+type UserGroupMembership = Pick<UserGroup, 'userId' | 'groupId'>
+
+export function usersBaseDN() {
+  return `${rdn('ou', appConfig.LDAP_USERS_OU)},${appConfig.LDAP_BASE_DN}`
+}
+
+export function groupsBaseDN() {
+  return `${rdn('ou', appConfig.LDAP_GROUPS_OU)},${appConfig.LDAP_BASE_DN}`
+}
+
+export function ldapUserDN(user: Pick<User, 'username'>) {
+  return `${rdn('uid', user.username)},${usersBaseDN()}`
+}
+
+export function ldapGroupDN(group: Pick<Group, 'name'>) {
+  return `${rdn('cn', group.name)},${groupsBaseDN()}`
+}
+
+export function dnEqual(a: string, b: string) {
+  return normalizeDN(a) === normalizeDN(b)
+}
+
+export async function getLDAPEntries(): Promise<LDAPEntry[]> {
+  const [users, groups, memberships] = await Promise.all([
+    db().table<User>(TABLES.USER).select(),
+    db().table<Group>(TABLES.GROUP).select(),
+    db().table<UserGroup>(TABLES.USER_GROUP).select('userId', 'groupId') as Promise<UserGroupMembership[]>,
+  ])
+
+  const groupsById = new Map(groups.map(group => [group.id, group]))
+  const groupNamesByUserId = new Map<string, string[]>()
+  const userIdsByGroupId = new Map<string, string[]>()
+
+  for (const membership of memberships) {
+    const group = groupsById.get(membership.groupId)
+    if (group) {
+      groupNamesByUserId.set(membership.userId, [...(groupNamesByUserId.get(membership.userId) ?? []), group.name])
+      userIdsByGroupId.set(membership.groupId, [...(userIdsByGroupId.get(membership.groupId) ?? []), membership.userId])
+    }
+  }
+
+  const activeUsers = users.filter(user => userVisibleInLDAP(user, groupNamesByUserId.get(user.id) ?? []))
+  const activeUsersById = new Map(activeUsers.map(user => [user.id, user]))
+
+  const entries: LDAPEntry[] = [
+    rootDSEEntry(),
+    baseEntry(),
+    organizationalUnitEntry(appConfig.LDAP_USERS_OU, usersBaseDN()),
+    organizationalUnitEntry(appConfig.LDAP_GROUPS_OU, groupsBaseDN()),
+  ]
+
+  for (const user of activeUsers) {
+    entries.push(userEntry(user, groupNamesByUserId.get(user.id) ?? []))
+  }
+
+  for (const group of groups) {
+    const groupUsers = (userIdsByGroupId.get(group.id) ?? [])
+      .map(userId => activeUsersById.get(userId))
+      .filter((user): user is User => !!user)
+
+    entries.push(groupEntry(group, groupUsers))
+  }
+
+  return entries
+}
+
+export async function getLDAPEntryByDN(dn: string): Promise<LDAPEntry | undefined> {
+  return (await getLDAPEntries()).find(entry => dnEqual(entry.dn, dn))
+}
+
+export async function getLDAPUserByDN(dn: string): Promise<User | undefined> {
+  const users = await db().table<User>(TABLES.USER).select()
+  return users.find(user => dnEqual(ldapUserDN(user), dn))
+}
+
+export function entryInScope(baseDN: string, entryDN: string, scope: LDAPSearchScope) {
+  const base = parseDN(baseDN)
+  const entry = parseDN(entryDN)
+
+  if (!base || !entry) {
+    return false
+  }
+
+  switch (searchScope(scope)) {
+    case 'base':
+      return rdnsEqual(entry, base)
+    case 'one':
+      return entry.length === base.length + 1 && dnEndsWith(entry, base)
+    case 'sub':
+      return rdnsEqual(entry, base) || dnEndsWith(entry, base)
+  }
+}
+
+export function searchScope(scope: LDAPSearchScope): 'base' | 'one' | 'sub' {
+  switch (scope) {
+    case 0:
+    case 'base':
+      return 'base'
+    case 1:
+    case 'one':
+      return 'one'
+    case 2:
+    case 'sub':
+      return 'sub'
+  }
+}
+
+function rootDSEEntry(): LDAPEntry {
+  return {
+    dn: '',
+    attributes: attrs({
+      objectClass: ['top'],
+      namingContexts: [appConfig.LDAP_BASE_DN],
+      supportedLDAPVersion: ['3'],
+      supportedFeatures: ['1.3.6.1.4.1.4203.1.5.1'],
+      vendorName: 'VoidAuth',
+      vendorVersion: 'VoidAuth',
+    }),
+  }
+}
+
+function baseEntry(): LDAPEntry {
+  return {
+    dn: appConfig.LDAP_BASE_DN,
+    attributes: attrs({
+      objectClass: ['top', 'dcObject', 'organization'],
+      dc: firstDcValue(appConfig.LDAP_BASE_DN),
+      o: appConfig.APP_TITLE,
+    }),
+  }
+}
+
+function organizationalUnitEntry(ou: string, dn: string): LDAPEntry {
+  return {
+    dn,
+    attributes: attrs({
+      objectClass: ['top', 'organizationalUnit'],
+      ou,
+    }),
+  }
+}
+
+function userEntry(user: User, groupNames: string[]): LDAPEntry {
+  const cn = user.name || user.username
+  const groupDNs = groupNames.map(name => ldapGroupDN({ name })).sort((a, b) => a.localeCompare(b))
+
+  return {
+    dn: ldapUserDN(user),
+    attributes: attrs({
+      objectClass: ['top', 'person', 'organizationalPerson', 'inetOrgPerson', 'posixAccount'],
+      entryUUID: user.id,
+      uid: user.username,
+      cn,
+      sn: surname(cn),
+      displayName: cn,
+      givenName: givenName(cn),
+      mail: user.email,
+      uidNumber: numericId(user.id),
+      gidNumber: numericId(appConfig.LDAP_BASE_DN),
+      homeDirectory: `/home/${user.username}`,
+      loginShell: '/bin/false',
+      memberOf: groupDNs,
+      isMemberOf: groupDNs,
+      voidAuthApproved: String(!!user.approved),
+      voidAuthEmailVerified: String(!!user.emailVerified),
+    }),
+  }
+}
+
+function groupEntry(group: Group, users: User[]): LDAPEntry {
+  const members = users.map(user => ldapUserDN(user)).sort((a, b) => a.localeCompare(b))
+
+  return {
+    dn: ldapGroupDN(group),
+    attributes: attrs({
+      objectClass: ['top', 'groupOfNames', 'groupOfUniqueNames', 'posixGroup'],
+      entryUUID: group.id,
+      cn: group.name,
+      description: group.name,
+      gidNumber: numericId(group.id),
+      member: members,
+      uniqueMember: members,
+      memberUid: users.map(user => user.username).sort((a, b) => a.localeCompare(b)),
+    }),
+  }
+}
+
+function userVisibleInLDAP(user: User, groupNames: string[]) {
+  const state = {
+    approved: !!user.approved,
+    emailVerified: !!user.emailVerified,
+    expiresAt: user.expiresAt ?? null,
+    hasEmail: !!user.email,
+    isAdmin: groupNames.some(name => name === ADMIN_GROUP),
+  }
+
+  return !isUnapproved(state, appConfig.SIGNUP_REQUIRES_APPROVAL)
+    && !isExpired(state)
+    && !isUnverifiedEmail(state, !!appConfig.EMAIL_VERIFICATION)
+}
+
+function attrs(input: Record<string, string | string[] | undefined | null>): LDAPAttributes {
+  const output: LDAPAttributes = {}
+
+  for (const [key, value] of Object.entries(input)) {
+    if (Array.isArray(value)) {
+      if (value.length) {
+        output[key] = value
+      }
+    } else if (value != null && value !== '') {
+      output[key] = value
+    }
+  }
+
+  return output
+}
+
+function rdn(attribute: string, value: string) {
+  return `${escapeDNValue(attribute)}=${escapeDNValue(value)}`
+}
+
+function firstDcValue(baseDN: string) {
+  return /^dc=([^,]+)/i.exec(baseDN)?.[1] ?? appConfig.APP_TITLE
+}
+
+function surname(name: string) {
+  return name.trim().split(/\s+/).at(-1) || name
+}
+
+function givenName(name: string) {
+  return name.trim().split(/\s+/).at(0) || name
+}
+
+function numericId(input: string) {
+  const hash = createHash('sha256').update(input).digest()
+  return String(10000 + (hash.readUInt32BE(0) % 2000000000))
+}
+
+function normalizeDN(dn: string) {
+  const parsed = parseDN(dn)
+  return parsed
+    ? parsed.map(rdn => rdn.map(([name, value]) => `${name}=${value}`).join('+')).join(',')
+    : dn.trim().toLowerCase()
+}
+
+function parseDN(dn: string) {
+  const input = dn.trim()
+
+  if (!input) {
+    return []
+  }
+
+  const rdns = splitUnescaped(input, ',').map(part => splitUnescaped(part, '+').map((attributeValue) => {
+    const equalsIndex = findUnescaped(attributeValue, '=')
+
+    if (equalsIndex < 1) {
+      return undefined
+    }
+
+    return [
+      attributeValue.slice(0, equalsIndex).trim().toLowerCase(),
+      unescapeDNValue(attributeValue.slice(equalsIndex + 1).trim()).toLowerCase(),
+    ] as [string, string]
+  }))
+
+  if (rdns.some(rdn => rdn.some(value => !value))) {
+    return undefined
+  }
+
+  return rdns as [string, string][][]
+}
+
+function rdnsEqual(a: [string, string][][], b: [string, string][][]) {
+  return a.length === b.length && dnEndsWith(a, b)
+}
+
+function dnEndsWith(dn: [string, string][][], suffix: [string, string][][]) {
+  if (suffix.length > dn.length) {
+    return false
+  }
+
+  const offset = dn.length - suffix.length
+  return suffix.every((rdn, index) => {
+    const entryRDN = dn[offset + index]
+    return !!entryRDN && rdnEqual(entryRDN, rdn)
+  })
+}
+
+function rdnEqual(a: [string, string][], b: [string, string][]) {
+  if (a.length !== b.length) {
+    return false
+  }
+
+  const expected = new Set(b.map(([name, value]) => `${name}=${value}`))
+  return a.every(([name, value]) => expected.has(`${name}=${value}`))
+}
+
+function splitUnescaped(input: string, separator: string) {
+  const parts: string[] = []
+  let current = ''
+  let escaped = false
+
+  for (const char of input) {
+    if (escaped) {
+      current += char
+      escaped = false
+    } else if (char === '\\') {
+      current += char
+      escaped = true
+    } else if (char === separator) {
+      parts.push(current)
+      current = ''
+    } else {
+      current += char
+    }
+  }
+
+  parts.push(current)
+  return parts
+}
+
+function findUnescaped(input: string, target: string) {
+  let escaped = false
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index]
+
+    if (escaped) {
+      escaped = false
+    } else if (char === '\\') {
+      escaped = true
+    } else if (char === target) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function escapeDNValue(value: string) {
+  return value.replace(/[\\,+"<>;=#]/g, char => `\\${char}`).replace(/^ /, '\\ ').replace(/ $/, '\\ ')
+}
+
+function unescapeDNValue(value: string) {
+  return value.replace(/\\([0-9a-fA-F]{2}|.)/g, (_match, escaped: string) => {
+    if (/^[0-9a-fA-F]{2}$/.test(escaped)) {
+      return String.fromCharCode(Number.parseInt(escaped, 16))
+    }
+
+    return escaped
+  })
+}

--- a/server/ldap/server.ts
+++ b/server/ldap/server.ts
@@ -1,0 +1,687 @@
+import fs from 'node:fs'
+import net, { type Socket } from 'node:net'
+import tls from 'node:tls'
+import appConfig from '../util/config'
+import { logger } from '../util/logger'
+import { checkPasswordHash, getUserById } from '../db/user'
+import { userCanLogin } from '../util/auth'
+import {
+  dnEqual,
+  entryInScope,
+  getLDAPEntries,
+  getLDAPEntryByDN,
+  getLDAPUserByDN,
+  type LDAPAttributes,
+  type LDAPEntry,
+  type LDAPSearchScope,
+  searchScope,
+} from './directory'
+
+const RESULT_SUCCESS = 0
+const RESULT_OPERATIONS_ERROR = 1
+const RESULT_COMPARE_FALSE = 5
+const RESULT_COMPARE_TRUE = 6
+const RESULT_PROTOCOL_ERROR = 2
+const RESULT_INVALID_CREDENTIALS = 49
+const RESULT_INSUFFICIENT_ACCESS = 50
+
+type LDAPServer = net.Server | tls.Server
+
+type LDAPConnection = {
+  bindDN: string
+  buffer: Buffer
+  socket: Socket
+}
+
+type LDAPMessage = {
+  id: number
+  op: BERElement
+}
+
+type BERElement = {
+  tag: number
+  value: Buffer
+}
+
+type LDAPFilter
+  = { type: 'and', filters: LDAPFilter[] }
+    | { type: 'or', filters: LDAPFilter[] }
+    | { type: 'not', filter: LDAPFilter }
+    | { type: 'equality', attribute: string, value: string }
+    | { type: 'substrings', attribute: string, initial?: string, any: string[], final?: string }
+    | { type: 'greaterOrEqual' | 'lessOrEqual' | 'approx', attribute: string, value: string }
+    | { type: 'present', attribute: string }
+
+type SearchRequest = {
+  baseDN: string
+  scope: LDAPSearchScope
+  sizeLimit: number
+  filter: LDAPFilter
+  attributes: string[]
+}
+
+type CompareRequest = {
+  dn: string
+  attribute: string
+  value: string
+}
+
+export function startLDAPServer(): LDAPServer | undefined {
+  if (!appConfig.LDAP_ENABLED) {
+    return
+  }
+
+  const server = appConfig.LDAP_TLS_CERT_FILE && appConfig.LDAP_TLS_KEY_FILE
+    ? tls.createServer({
+        cert: fs.readFileSync(appConfig.LDAP_TLS_CERT_FILE),
+        key: fs.readFileSync(appConfig.LDAP_TLS_KEY_FILE),
+      }, (socket) => {
+        handleConnection(socket)
+      })
+    : net.createServer((socket) => {
+        handleConnection(socket)
+      })
+
+  server.on('error', (error: Error) => {
+    logger({
+      level: 'error',
+      message: 'LDAP Server error',
+      errors: [error],
+    })
+  })
+
+  server.listen(appConfig.LDAP_PORT, appConfig.LDAP_HOST, () => {
+    const scheme = appConfig.LDAP_TLS_CERT_FILE ? 'ldaps' : 'ldap'
+    logger({
+      level: 'info',
+      message: `LDAP Server listening at ${scheme}://${appConfig.LDAP_HOST}:${String(appConfig.LDAP_PORT)}`,
+    })
+  })
+
+  return server
+}
+
+function handleConnection(socket: Socket) {
+  const connection: LDAPConnection = {
+    bindDN: '',
+    buffer: Buffer.alloc(0),
+    socket,
+  }
+
+  socket.on('data', (chunk) => {
+    connection.buffer = Buffer.concat([connection.buffer, chunk])
+    void processBuffer(connection)
+  })
+
+  socket.on('error', (error) => {
+    logger({
+      level: 'error',
+      message: 'LDAP client connection error',
+      errors: [error],
+    })
+  })
+}
+
+async function processBuffer(connection: LDAPConnection) {
+  while (connection.buffer.length) {
+    const frame = readLDAPFrame(connection.buffer)
+
+    if (!frame) {
+      return
+    }
+
+    connection.buffer = connection.buffer.subarray(frame.length)
+
+    try {
+      const message = readLDAPMessage(frame.value)
+      await handleMessage(connection, message)
+    } catch (error) {
+      logger({
+        level: 'error',
+        message: 'LDAP protocol error',
+        errors: error instanceof Error ? [error] : [{ message: String(error) }],
+      })
+      connection.socket.write(ldapResult(0, 0x61, RESULT_PROTOCOL_ERROR))
+    }
+  }
+}
+
+async function handleMessage(connection: LDAPConnection, message: LDAPMessage) {
+  switch (message.op.tag) {
+    case 0x60:
+      await handleBind(connection, message.id, message.op)
+      return
+    case 0x63:
+      await handleSearch(connection, message.id, message.op)
+      return
+    case 0x6e:
+      await handleCompare(connection, message.id, message.op)
+      return
+    case 0x42:
+      connection.socket.end()
+      return
+    default:
+      connection.socket.write(ldapResult(message.id, 0x61, RESULT_PROTOCOL_ERROR, '', 'Unsupported LDAP operation'))
+  }
+}
+
+async function handleBind(connection: LDAPConnection, messageId: number, op: BERElement) {
+  try {
+    const reader = new BERReader(op.value)
+    const version = reader.readInteger()
+    const dn = reader.readString()
+    const auth = reader.readElement()
+    const password = auth.tag === 0x80 ? auth.value.toString('utf8') : ''
+
+    if (version !== 3 || auth.tag !== 0x80) {
+      connection.socket.write(ldapResult(messageId, 0x61, RESULT_PROTOCOL_ERROR))
+      return
+    }
+
+    if (dnEqual(dn, '') && password === '') {
+      connection.bindDN = ''
+      connection.socket.write(ldapResult(messageId, 0x61, RESULT_SUCCESS))
+      return
+    }
+
+    if (dnEqual(dn, appConfig.LDAP_BIND_DN)) {
+      if (appConfig.LDAP_BIND_PASSWORD && password === appConfig.LDAP_BIND_PASSWORD) {
+        connection.bindDN = appConfig.LDAP_BIND_DN
+        connection.socket.write(ldapResult(messageId, 0x61, RESULT_SUCCESS))
+        return
+      }
+
+      connection.socket.write(ldapResult(messageId, 0x61, RESULT_INVALID_CREDENTIALS))
+      return
+    }
+
+    const user = await getLDAPUserByDN(dn)
+    if (!user || !password || !await checkPasswordHash(user.id, password)) {
+      connection.socket.write(ldapResult(messageId, 0x61, RESULT_INVALID_CREDENTIALS))
+      return
+    }
+
+    const details = await getUserById(user.id)
+    if (!userCanLogin(details, ['pwd'])) {
+      connection.socket.write(ldapResult(messageId, 0x61, RESULT_INVALID_CREDENTIALS))
+      return
+    }
+
+    connection.bindDN = dn
+    connection.socket.write(ldapResult(messageId, 0x61, RESULT_SUCCESS))
+  } catch (error) {
+    logger({
+      level: 'error',
+      message: 'LDAP bind failed',
+      errors: error instanceof Error ? [error] : [{ message: String(error) }],
+    })
+    connection.socket.write(ldapResult(messageId, 0x61, RESULT_OPERATIONS_ERROR))
+  }
+}
+
+async function handleSearch(connection: LDAPConnection, messageId: number, op: BERElement) {
+  try {
+    const req = readSearchRequest(op.value)
+
+    if (!canSearch(connection) && !(dnEqual(req.baseDN, '') && searchScope(req.scope) === 'base')) {
+      connection.socket.write(ldapResult(messageId, 0x65, RESULT_INSUFFICIENT_ACCESS))
+      return
+    }
+
+    const entries = await getLDAPEntries()
+    let sent = 0
+
+    for (const entry of entries) {
+      if (req.sizeLimit && sent >= req.sizeLimit) {
+        break
+      }
+
+      if (entryInScope(req.baseDN, entry.dn, req.scope) && filterMatches(req.filter, entry.attributes)) {
+        connection.socket.write(searchEntry(messageId, entry, req.attributes))
+        sent += 1
+      }
+    }
+
+    connection.socket.write(ldapResult(messageId, 0x65, RESULT_SUCCESS))
+  } catch (error) {
+    logger({
+      level: 'error',
+      message: 'LDAP search failed',
+      errors: error instanceof Error ? [error] : [{ message: String(error) }],
+    })
+    connection.socket.write(ldapResult(messageId, 0x65, RESULT_OPERATIONS_ERROR))
+  }
+}
+
+async function handleCompare(connection: LDAPConnection, messageId: number, op: BERElement) {
+  try {
+    if (!canSearch(connection)) {
+      connection.socket.write(ldapResult(messageId, 0x6f, RESULT_INSUFFICIENT_ACCESS))
+      return
+    }
+
+    const req = readCompareRequest(op.value)
+    const entry = await getLDAPEntryByDN(req.dn)
+    const values = attributeValues(entry?.attributes, req.attribute)
+    const result = values.some(value => value === req.value) ? RESULT_COMPARE_TRUE : RESULT_COMPARE_FALSE
+
+    connection.socket.write(ldapResult(messageId, 0x6f, result))
+  } catch (error) {
+    logger({
+      level: 'error',
+      message: 'LDAP compare failed',
+      errors: error instanceof Error ? [error] : [{ message: String(error) }],
+    })
+    connection.socket.write(ldapResult(messageId, 0x6f, RESULT_OPERATIONS_ERROR))
+  }
+}
+
+function canSearch(connection: LDAPConnection) {
+  return appConfig.LDAP_ALLOW_ANONYMOUS_SEARCH
+    || dnEqual(connection.bindDN, appConfig.LDAP_BIND_DN)
+    || (!!connection.bindDN && !dnEqual(connection.bindDN, appConfig.LDAP_BIND_DN))
+}
+
+function readSearchRequest(value: Buffer): SearchRequest {
+  const reader = new BERReader(value)
+  const baseDN = reader.readString()
+  const scope = reader.readInteger() as LDAPSearchScope
+  reader.readInteger()
+  const sizeLimit = reader.readInteger()
+  reader.readInteger()
+  reader.readBoolean()
+  const filter = readFilter(reader.readElement())
+  const attributes = reader.readSequence(0x30).map(element => element.value.toString('utf8'))
+
+  return { baseDN, scope, sizeLimit, filter, attributes }
+}
+
+function readCompareRequest(value: Buffer): CompareRequest {
+  const reader = new BERReader(value)
+  const dn = reader.readString()
+  const avaElement = reader.readElement()
+
+  if (avaElement.tag !== 0x30) {
+    throw new Error('Expected compare attribute value assertion')
+  }
+
+  const ava = new BERReader(avaElement.value)
+  const attribute = ava.readString()
+  const requestValue = ava.readString()
+
+  return { dn, attribute, value: requestValue }
+}
+
+function readFilter(element: BERElement): LDAPFilter {
+  switch (element.tag) {
+    case 0xa0:
+      return { type: 'and', filters: new BERReader(element.value).readAll().map(readFilter) }
+    case 0xa1:
+      return { type: 'or', filters: new BERReader(element.value).readAll().map(readFilter) }
+    case 0xa2:
+      return { type: 'not', filter: readFilter(new BERReader(element.value).readElement()) }
+    case 0xa3: {
+      const reader = new BERReader(element.value)
+      return { type: 'equality', attribute: reader.readString(), value: reader.readString() }
+    }
+    case 0xa4:
+      return readSubstringFilter(element.value)
+    case 0xa5: {
+      const reader = new BERReader(element.value)
+      return { type: 'greaterOrEqual', attribute: reader.readString(), value: reader.readString() }
+    }
+    case 0xa6: {
+      const reader = new BERReader(element.value)
+      return { type: 'lessOrEqual', attribute: reader.readString(), value: reader.readString() }
+    }
+    case 0x87:
+      return { type: 'present', attribute: element.value.toString('utf8') }
+    case 0xa8: {
+      const reader = new BERReader(element.value)
+      return { type: 'approx', attribute: reader.readString(), value: reader.readString() }
+    }
+    default:
+      throw new Error(`Unsupported LDAP filter: 0x${element.tag.toString(16)}`)
+  }
+}
+
+function readSubstringFilter(value: Buffer): LDAPFilter {
+  const reader = new BERReader(value)
+  const attribute = reader.readString()
+  const substringsElement = reader.readElement()
+
+  if (substringsElement.tag !== 0x30) {
+    throw new Error('Expected substring sequence')
+  }
+
+  const substrings = new BERReader(substringsElement.value).readAll()
+  const filter: LDAPFilter = { type: 'substrings', attribute, any: [] }
+
+  for (const substring of substrings) {
+    const value = substring.value.toString('utf8')
+
+    if (substring.tag === 0x80) {
+      filter.initial = value
+    } else if (substring.tag === 0x81) {
+      filter.any.push(value)
+    } else if (substring.tag === 0x82) {
+      filter.final = value
+    }
+  }
+
+  return filter
+}
+
+function filterMatches(filter: LDAPFilter, attributes: LDAPAttributes): boolean {
+  switch (filter.type) {
+    case 'and':
+      return filter.filters.every(child => filterMatches(child, attributes))
+    case 'or':
+      return filter.filters.some(child => filterMatches(child, attributes))
+    case 'not':
+      return !filterMatches(filter.filter, attributes)
+    case 'equality':
+    case 'approx':
+      return attributeValues(attributes, filter.attribute).some(value => value.toLowerCase() === filter.value.toLowerCase())
+    case 'greaterOrEqual':
+      return attributeValues(attributes, filter.attribute).some(value => value.localeCompare(filter.value) >= 0)
+    case 'lessOrEqual':
+      return attributeValues(attributes, filter.attribute).some(value => value.localeCompare(filter.value) <= 0)
+    case 'present':
+      return attributeValues(attributes, filter.attribute).length > 0
+    case 'substrings':
+      return attributeValues(attributes, filter.attribute).some(value => substringMatches(value, filter))
+  }
+}
+
+function substringMatches(input: string, filter: Extract<LDAPFilter, { type: 'substrings' }>) {
+  let remaining = input.toLowerCase()
+
+  if (filter.initial) {
+    const initial = filter.initial.toLowerCase()
+    if (!remaining.startsWith(initial)) {
+      return false
+    }
+    remaining = remaining.slice(initial.length)
+  }
+
+  for (const part of filter.any) {
+    const index = remaining.indexOf(part.toLowerCase())
+
+    if (index < 0) {
+      return false
+    }
+
+    remaining = remaining.slice(index + part.length)
+  }
+
+  return filter.final ? remaining.endsWith(filter.final.toLowerCase()) : true
+}
+
+function attributeValues(attributes: LDAPAttributes | undefined, name: string) {
+  if (!attributes) {
+    return []
+  }
+
+  const key = Object.keys(attributes).find(key => key.toLowerCase() === name.toLowerCase())
+  const value = key ? attributes[key] : undefined
+
+  if (!value) {
+    return []
+  }
+
+  return Array.isArray(value) ? value : [value]
+}
+
+function searchEntry(messageId: number, entry: LDAPEntry, requestedAttributes: string[]) {
+  const attributes = Object.entries(selectedAttributes(entry.attributes, requestedAttributes)).map(([name, values]) => berSequence([
+    berOctetString(name),
+    berSet((Array.isArray(values) ? values : [values]).map(value => berOctetString(value))),
+  ]))
+
+  return ldapMessage(messageId, 0x64, [
+    berOctetString(entry.dn),
+    berSequence(attributes),
+  ])
+}
+
+function selectedAttributes(attributes: LDAPAttributes, requestedAttributes: string[]) {
+  const names = requestedAttributes.map(attribute => attribute.toLowerCase())
+
+  if (!names.length || names.includes('*')) {
+    return attributes
+  }
+
+  const selected: LDAPAttributes = {}
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (names.includes(key.toLowerCase())) {
+      selected[key] = value
+    }
+  }
+
+  return selected
+}
+
+function ldapResult(messageId: number, tag: number, resultCode: number, matchedDN = '', diagnosticMessage = '') {
+  return ldapMessage(messageId, tag, [
+    berEnumerated(resultCode),
+    berOctetString(matchedDN),
+    berOctetString(diagnosticMessage),
+  ])
+}
+
+function ldapMessage(messageId: number, applicationTag: number, children: Buffer[]) {
+  return berSequence([
+    berInteger(messageId),
+    berTLV(applicationTag, Buffer.concat(children)),
+  ])
+}
+
+function readLDAPFrame(buffer: Buffer) {
+  if (buffer[0] !== 0x30) {
+    throw new Error('LDAP message must be a sequence')
+  }
+
+  const length = readLength(buffer, 1)
+  if (!length || buffer.length < 1 + length.bytes + length.value) {
+    return
+  }
+
+  return {
+    length: 1 + length.bytes + length.value,
+    value: buffer.subarray(1 + length.bytes, 1 + length.bytes + length.value),
+  }
+}
+
+function readLDAPMessage(value: Buffer): LDAPMessage {
+  const reader = new BERReader(value)
+  const id = reader.readInteger()
+  const op = reader.readElement()
+
+  return { id, op }
+}
+
+class BERReader {
+  private offset = 0
+
+  constructor(private readonly buffer: Buffer) {}
+
+  readAll() {
+    const elements: BERElement[] = []
+
+    while (this.offset < this.buffer.length) {
+      elements.push(this.readElement())
+    }
+
+    return elements
+  }
+
+  readSequence(tag = 0x30) {
+    const element = this.readElement()
+
+    if (element.tag !== tag) {
+      throw new Error(`Expected BER tag 0x${tag.toString(16)}, got 0x${element.tag.toString(16)}`)
+    }
+
+    return new BERReader(element.value).readAll()
+  }
+
+  readInteger() {
+    const element = this.readElement()
+
+    if (element.tag !== 0x02 && element.tag !== 0x0a) {
+      throw new Error(`Expected integer, got 0x${element.tag.toString(16)}`)
+    }
+
+    let value = 0
+
+    for (const byte of element.value) {
+      value = (value << 8) | byte
+    }
+
+    return value
+  }
+
+  readBoolean() {
+    const element = this.readElement()
+
+    if (element.tag !== 0x01 || element.value.length !== 1) {
+      throw new Error('Expected boolean')
+    }
+
+    return element.value[0] !== 0
+  }
+
+  readString() {
+    const element = this.readElement()
+
+    if (element.tag !== 0x04) {
+      throw new Error(`Expected string, got 0x${element.tag.toString(16)}`)
+    }
+
+    return element.value.toString('utf8')
+  }
+
+  readElement(): BERElement {
+    if (this.offset + 2 > this.buffer.length) {
+      throw new Error('Incomplete BER element')
+    }
+
+    const tag = this.buffer[this.offset]
+
+    if (tag == null) {
+      throw new Error('Incomplete BER element')
+    }
+    const length = readLength(this.buffer, this.offset + 1)
+
+    if (!length || this.offset + 1 + length.bytes + length.value > this.buffer.length) {
+      throw new Error('Invalid BER length')
+    }
+
+    const valueStart = this.offset + 1 + length.bytes
+    const valueEnd = valueStart + length.value
+    this.offset = valueEnd
+
+    return {
+      tag,
+      value: this.buffer.subarray(valueStart, valueEnd),
+    }
+  }
+}
+
+function readLength(buffer: Buffer, offset: number) {
+  const first = buffer[offset]
+
+  if (first == null) {
+    return
+  }
+
+  if (!(first & 0x80)) {
+    return { bytes: 1, value: first }
+  }
+
+  const byteCount = first & 0x7f
+
+  if (!byteCount || byteCount > 4 || offset + byteCount >= buffer.length) {
+    return
+  }
+
+  let value = 0
+
+  for (let index = 0; index < byteCount; index += 1) {
+    const byte = buffer[offset + 1 + index]
+
+    if (byte == null) {
+      return
+    }
+
+    value = (value << 8) | byte
+  }
+
+  return { bytes: 1 + byteCount, value }
+}
+
+function berSequence(children: Buffer[]) {
+  return berTLV(0x30, Buffer.concat(children))
+}
+
+function berSet(children: Buffer[]) {
+  return berTLV(0x31, Buffer.concat(children))
+}
+
+function berInteger(value: number) {
+  const bytes: number[] = []
+  let remaining = value
+
+  do {
+    bytes.unshift(remaining & 0xff)
+    remaining >>= 8
+  } while (remaining)
+
+  if ((bytes[0] ?? 0) & 0x80) {
+    bytes.unshift(0)
+  }
+
+  return berTLV(0x02, Buffer.from(bytes))
+}
+
+function berEnumerated(value: number) {
+  const bytes: number[] = []
+  let remaining = value
+
+  do {
+    bytes.unshift(remaining & 0xff)
+    remaining >>= 8
+  } while (remaining)
+
+  if ((bytes[0] ?? 0) & 0x80) {
+    bytes.unshift(0)
+  }
+
+  return berTLV(0x0a, Buffer.from(bytes))
+}
+
+function berOctetString(value: string) {
+  return berTLV(0x04, Buffer.from(value, 'utf8'))
+}
+
+function berTLV(tag: number, value: Buffer) {
+  return Buffer.concat([Buffer.from([tag]), berLength(value.length), value])
+}
+
+function berLength(length: number) {
+  if (length < 0x80) {
+    return Buffer.from([length])
+  }
+
+  const bytes: number[] = []
+  let remaining = length
+
+  while (remaining) {
+    bytes.unshift(remaining & 0xff)
+    remaining >>= 8
+  }
+
+  return Buffer.from([0x80 | bytes.length, ...bytes])
+}

--- a/server/util/config.ts
+++ b/server/util/config.ts
@@ -68,6 +68,19 @@ class Config {
   SMTP_TLS_CIPHERS?: string
   SMTP_TLS_MIN_VERSION?: SecureVersion
 
+  // LDAP
+  LDAP_ENABLED: boolean = false
+  LDAP_HOST = '0.0.0.0'
+  LDAP_PORT: number = 3890
+  LDAP_BASE_DN = 'dc=voidauth'
+  LDAP_USERS_OU = 'people'
+  LDAP_GROUPS_OU = 'groups'
+  LDAP_BIND_DN = 'cn=ldap_bind,dc=voidauth'
+  LDAP_BIND_PASSWORD?: string
+  LDAP_ALLOW_ANONYMOUS_SEARCH: boolean = false
+  LDAP_TLS_CERT_FILE?: string
+  LDAP_TLS_KEY_FILE?: string
+
   DECLARED_CLIENTS = new Map<string, ClientResponse>()
 }
 
@@ -79,6 +92,7 @@ function assignConfigValue(key: keyof Config, value: string | undefined) {
     case 'SMTP_PORT':
     case 'PASSWORD_STRENGTH':
     case 'API_RATELIMIT':
+    case 'LDAP_PORT':
       appConfig[key] = posInt(value) ?? appConfig[key]
       break
 
@@ -105,6 +119,8 @@ function assignConfigValue(key: keyof Config, value: string | undefined) {
     case 'DB_SSL_VERIFICATION':
     case 'MIGRATE_TO_DB_SSL':
     case 'MIGRATE_TO_DB_SSL_VERIFICATION':
+    case 'LDAP_ENABLED':
+    case 'LDAP_ALLOW_ANONYMOUS_SEARCH':
       appConfig[key] = booleanString(value) ?? appConfig[key]
       break
 
@@ -130,6 +146,9 @@ function assignConfigValue(key: keyof Config, value: string | undefined) {
     case 'SMTP_USER':
     case 'SMTP_PASS':
     case 'SMTP_TLS_CIPHERS':
+    case 'LDAP_BIND_PASSWORD':
+    case 'LDAP_TLS_CERT_FILE':
+    case 'LDAP_TLS_KEY_FILE':
       appConfig[key] = stringOnly(value) ?? appConfig[key]
       break
 
@@ -472,6 +491,29 @@ if (appConfig.APP_FONT) {
     appConfig.APP_FONT += ','
   }
   appConfig.APP_FONT += ' '
+}
+
+if (appConfig.LDAP_ENABLED) {
+  appConfig.LDAP_BASE_DN = appConfig.LDAP_BASE_DN.trim()
+  appConfig.LDAP_USERS_OU = appConfig.LDAP_USERS_OU.trim()
+  appConfig.LDAP_GROUPS_OU = appConfig.LDAP_GROUPS_OU.trim()
+  appConfig.LDAP_BIND_DN = appConfig.LDAP_BIND_DN.trim()
+
+  if (!appConfig.LDAP_BASE_DN || !appConfig.LDAP_USERS_OU || !appConfig.LDAP_GROUPS_OU) {
+    logger({
+      level: 'error',
+      message: 'LDAP_BASE_DN, LDAP_USERS_OU, and LDAP_GROUPS_OU must be non-empty when LDAP_ENABLED is true.',
+    })
+    exit(1)
+  }
+
+  if (!!appConfig.LDAP_TLS_CERT_FILE !== !!appConfig.LDAP_TLS_KEY_FILE) {
+    logger({
+      level: 'error',
+      message: 'LDAP_TLS_CERT_FILE and LDAP_TLS_KEY_FILE must be set together.',
+    })
+    exit(1)
+  }
 }
 
 //


### PR DESCRIPTION
## Description

Added optional LDAP directory server functionality, as requested and discussed [here](https://github.com/voidauth/voidauth/issues/377) and [here](https://github.com/voidauth/voidauth/issues/237).

The image now accepts new `LDAP_*` environment variables to enable and configure the LDAP server.

If enabled, a separate LDAP server starts on another port (`3890` by default) to listen to LDAP queries.

The LDAP server is currently read-only and this PR is mostly a PoC, as I'm no expert in LDAP (learned it last night) and additional functionality may be added. It tries to implement most of the common LDAP endpoints and functionality, possibly working as a full replacement for LLDAP. It supports service-account bind, user DN bind, search, compare, RootDSE discoveries, user and group entries, and membership attributes.

It only implements the LDAP endpoints functionality discussed [here](https://github.com/voidauth/voidauth/issues/237), allowing other services to use VoidAuth as an LDAP server. It does not implement connecting to an LDAP server and using it as a source for users/groups in VoidAuth.

Documentation was updated too. The frontend is untouched.

### Changes

- Add optional LDAP server controlled by `LDAP_ENABLED`.
- Add LDAP configuration for host, port, base DN, people/groups OUs, service bind DN/password, anonymous search, and LDAPS cert/key files.
- Expose users under `ou=people,{LDAP_BASE_DN}`.
- Expose groups under `ou=groups,{LDAP_BASE_DN}`.
- Support LDAP operations:
  - simple bind
  - search
  - compare
  - unbind
  - RootDSE base search
- Support common object classes and attributes:
  - `inetOrgPerson`
  - `posixAccount`
  - `groupOfNames`
  - `groupOfUniqueNames`
  - `posixGroup`
  - `memberOf`
  - `member`
  - `uniqueMember`
  - `memberUid`
- Filter LDAP-visible users using existing VoidAuth user state checks.
- Use VoidAuth password verification for LDAP user binds.
- Add LDAP server documentation and environment variable descriptions.
- Expose default LDAP port `3890` in the Dockerfile.

## Related Tickets & Documents

- Issue [#237](https://github.com/voidauth/voidauth/issues/237)
- Issue [#337](https://github.com/voidauth/voidauth/issues/377)
