### PR TITLE
Add SMTP_NOAUTH support for unauthenticated SMTP servers

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -165,6 +165,7 @@ All of these settings are ✅ recommended to be set to the correct values for yo
 | SMTP_SECURE | `false` | SMTP has TLS/SSL enabled. |
 | SMTP_USER | | SMTP username used to sign into email provider; ex `user@example.com` |
 | SMTP_PASS | | SMTP password used to sign into email provider |
+| SMTP_NOAUTH | `false` | Disable SMTP authentication. Useful for SMTP servers that do not require authentication, such as servers using IP whitelisting. When set to `true`, `SMTP_USER` and `SMTP_PASS` are not required. |
 | SMTP_IGNORE_CERT | `false` | SMTP Connection will ignore invalid and self-signed certificates from SMTP providers |
 | SMTP_TLS_CIPHERS | | TLS cipher to use, only set if required by your SMTP provider |
 | SMTP_TLS_MIN_VERSION | | Minimum TLS version, only set if required by your SMTP provider. Possible values are `TLSv1.3`, `TLSv1.2`, `TLSv1.1`, `TLSv1` |

--- a/server/util/config.ts
+++ b/server/util/config.ts
@@ -64,6 +64,7 @@ class Config {
   SMTP_SECURE = false
   SMTP_USER?: string
   SMTP_PASS?: string
+  SMTP_NOAUTH: boolean = false
   SMTP_IGNORE_CERT: boolean = false
   SMTP_TLS_CIPHERS?: string
   SMTP_TLS_MIN_VERSION?: SecureVersion
@@ -97,6 +98,7 @@ function assignConfigValue(key: keyof Config, value: string | undefined) {
 
     // booleans
     case 'SMTP_SECURE':
+    case 'SMTP_NOAUTH':
     case 'SMTP_IGNORE_CERT':
     case 'SIGNUP':
     case 'SIGNUP_REQUIRES_APPROVAL':

--- a/server/util/email.ts
+++ b/server/util/email.ts
@@ -25,10 +25,12 @@ const transportOptions: SMTPTransport.Options = {
   host: appConfig.SMTP_HOST,
   port: appConfig.SMTP_PORT,
   secure: appConfig.SMTP_SECURE,
-  auth: {
-    user: appConfig.SMTP_USER,
-    pass: appConfig.SMTP_PASS,
-  },
+  auth: appConfig.SMTP_NOAUTH
+    ? undefined
+    : {
+        user: appConfig.SMTP_USER,
+        pass: appConfig.SMTP_PASS,
+      },
   tls: {
     rejectUnauthorized: !appConfig.SMTP_IGNORE_CERT,
     ciphers: appConfig.SMTP_TLS_CIPHERS,


### PR DESCRIPTION
## Description
Adds a new SMTP_NOAUTH environment variable (boolean, defaults to false) that allows disabling SMTP authentication when connecting to mail servers that don't require credentials, such as those using IP whitelisting. (let me know if you prefer to just check if user and pass are empty and avoid an env variable)

When set to true, the nodemailer transport's auth object is set to undefined, skipping the authentication step entirely.

This avoids connection errors that occur when nodemailer attempts to authenticate against servers that have no auth mechanism configured.
