### PR TITLE
Properly Handle Missing i18n API Calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/voidauth/voidauth/release.yml)
 ![GitHub Release](https://img.shields.io/github/v/release/voidauth/voidauth?logo=github)
-![GitHub License](https://img.shields.io/github/license/voidauth/voidauth)
+![GitHub License](https://img.shields.io/badge/licence-AGPL--3.0-orange)
 ![GitHub Repo stars](https://img.shields.io/github/stars/voidauth/voidauth?style=flat&logo=github)
 
 

--- a/frontend/public/locales.json
+++ b/frontend/public/locales.json
@@ -1,4 +1,5 @@
 [
   { "code": "en-US", "display": "English" },
-  { "code": "de-DE", "display": "Deutsch" }
+  { "code": "de-DE", "display": "Deutsch" },
+  { "code": "zh-CN", "display": "中文" }
 ]

--- a/frontend/src/app/services/translation.service.ts
+++ b/frontend/src/app/services/translation.service.ts
@@ -69,25 +69,49 @@ export class TranslationService {
   private async _setInitialLang() {
     const previousLang = this.getLocalStorageLang()
     if (previousLang) {
-      if (await this._setLang(previousLang, true)) {
-        return
+      if (this.availableLangs.some(lang => lang.code === previousLang)) {
+        if (await this._setLang(previousLang, true)) {
+          return
+        }
+      } else {
+        console.error(`Previous language ${previousLang} is not available.`)
       }
     }
 
     const browserLang = this.translate.getBrowserCultureLang()
+    // browser language rules ("en" and "en-US" are valid, "en-GB-oxford" is not)
     if (browserLang) {
-      if (await this._setLang(browserLang, true)) {
-        return
+      // Try to parse the browser language to get a valid language code
+      const browserLangParts = browserLang.split('-').map((p, i) => i === 0 ? p.toLowerCase() : p.toUpperCase())
+      const parsedBrowserLang = browserLangParts.slice(0, 2).filter(p => !!p).join('-') // en-GB
+      const simplifiedBrowserLang = browserLangParts[0] // en
+      if (this.availableLangs.some(lang => lang.code === parsedBrowserLang)) {
+        if (await this._setLang(parsedBrowserLang, true)) {
+          return
+        }
+      } else if (simplifiedBrowserLang && simplifiedBrowserLang !== parsedBrowserLang) {
+        // Try to find an available language that matches (starts with) the simplified browser language
+        const foundAvailableLang = this.availableLangs.find(lang => lang.code.startsWith(simplifiedBrowserLang))
+        if (foundAvailableLang && await this._setLang(foundAvailableLang.code, true)) {
+          return
+        }
+      } else {
+        console.error(`Browser language ${browserLang} is not available.`)
       }
     }
 
     const fallbackLang = this.translate.getFallbackLang()
     if (fallbackLang) {
-      if (await this._setLang(fallbackLang, true)) {
-        return
+      if (this.availableLangs.some(lang => lang.code === fallbackLang)) {
+        if (await this._setLang(fallbackLang, true)) {
+          return
+        }
+      } else {
+        console.error(`Fallback language ${fallbackLang} is not available.`)
       }
     }
 
+    console.error('No available initial language found. Falling back to en-US.')
     await this._setLang('en-US', true)
   }
 

--- a/server/cli/server.ts
+++ b/server/cli/server.ts
@@ -210,6 +210,16 @@ export async function serve() {
     res.send(index)
   })
 
+  // Do not fallthrough to index.html for missing i18n files
+  app.use(`${basePath()}/i18n`, express.static(path.join(FE_ROOT, 'i18n'), {
+    index: false,
+    fallthrough: true,
+  }), (_req, res, _next) => {
+    res.status(404).send({
+      message: 'Internationalization file not found.',
+    })
+  })
+
   // frontend
   app.use(`${basePath()}/`,
     // if frontend matches specific paths, use different status codes
@@ -226,12 +236,6 @@ export async function serve() {
       fallthrough: true,
     }),
   )
-
-  // Do not fallthrough to index.html for missing i18n files
-  app.use(`${basePath()}/i18n`, express.static(path.join(FE_ROOT, 'i18n'), {
-    index: false,
-    fallthrough: false,
-  }))
 
   // Unresolved GET requests should return index if they start with basePath
   app.use((req, res, next) => {


### PR DESCRIPTION
## Description
- Properly Handle Missing i18n API Calls
- Add zh-CN translation to locales.json
- Do not attempt to set languages that do not have a translation listed in the locales.json Hardcode README license badge, it will not change and sometimes shows 'invalid' instead of the proper license

## Related Tickets & Documents
#435 

