### PR TITLE
Fix Issue Where Self Registered Users Are Not Being Redirected to Default Redirect When Approved

### DIFF
--- a/frontend/public/i18n/en-US.json
+++ b/frontend/public/i18n/en-US.json
@@ -82,7 +82,8 @@
     "content": "Your account needs approval before you can log in. Please wait or contact an administrator for help.",
     "title": "Approval Required",
     "actions": {
-      "login": "Login"
+      "login": "Login",
+      "try-again": "Try Again"
     }
   },
   "forbidden": {
@@ -569,7 +570,8 @@
     "title": "Account Access Expired",
     "content": "Your account access has expired, please contact an administrator to extend access.",
     "actions": {
-      "login": "Login"
+      "login": "Login",
+      "try-again": "Try Again"
     }
   },
   "passkey-name": {

--- a/frontend/src/app/components/header/header.component.html
+++ b/frontend/src/app/components/header/header.component.html
@@ -1,5 +1,5 @@
 <mat-toolbar>
-  @if (location.pathname === "/" && config?.defaultRedirect; as logoLink) {
+  @if (location.pathname === basePath + "/" && config?.defaultRedirect; as logoLink) {
     <a class="header-logo" [href]="logoLink">
       <app-logo></app-logo>
     </a>

--- a/frontend/src/app/components/header/header.component.ts
+++ b/frontend/src/app/components/header/header.component.ts
@@ -4,7 +4,7 @@ import { ThemeToggleComponent } from '../theme-toggle/theme-toggle.component'
 import { MaterialModule } from '../../material-module'
 import { UserService } from '../../services/user.service'
 import type { CurrentUserDetails } from '@shared/api-response/UserDetails'
-import { ConfigService } from '../../services/config.service'
+import { ConfigService, getBaseHrefPath } from '../../services/config.service'
 import { SpinnerService } from '../../services/spinner.service'
 import type { ConfigResponse } from '@shared/api-response/ConfigResponse'
 import { LogoComponent } from './logo.component'
@@ -28,6 +28,7 @@ export class HeaderComponent implements OnInit {
   public user?: CurrentUserDetails
   public config?: ConfigResponse
   public location = window.location
+  basePath = getBaseHrefPath()
 
   public toggleSidenav = output()
 

--- a/frontend/src/app/pages/approval-required/approval-required.component.html
+++ b/frontend/src/app/pages/approval-required/approval-required.component.html
@@ -3,7 +3,8 @@
   <mat-card-content>
     <p style="text-align: center">{{ "approval-required.content" | translate }}</p>
     <mat-card-actions>
-      <a mat-flat-button routerLink="/">{{ "approval-required.actions.login" | translate }}</a>
+      <a mat-button routerLink="/login">{{ "approval-required.actions.login" | translate }}</a>
+      <button mat-flat-button (click)="tryAgain()">{{ "approval-required.actions.try-again" | translate }}</button>
     </mat-card-actions>
   </mat-card-content>
 </mat-card>

--- a/frontend/src/app/pages/approval-required/approval-required.component.scss
+++ b/frontend/src/app/pages/approval-required/approval-required.component.scss
@@ -1,0 +1,13 @@
+mat-card-content {
+  padding-top: 32px;
+
+  mat-card-actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+
+    > * {
+      margin-left: 16px;
+    }
+  }
+}

--- a/frontend/src/app/pages/approval-required/approval-required.component.ts
+++ b/frontend/src/app/pages/approval-required/approval-required.component.ts
@@ -30,8 +30,8 @@ export class ApprovalRequiredComponent implements OnInit {
       // Check if interaction exists
       try {
         const info = await this.authService.interactionExists()
-        // If the user is privileged now, we can attempt to retry the interaction without user trigger
-        if (info.user?.isPrivileged) {
+        // If the user is approved now, we can attempt to retry the interaction without user trigger
+        if (info.user?.approved) {
           try {
             const result = await this.authService.interactionTryAgain()
             window.location.href = result.location

--- a/frontend/src/app/pages/approval-required/approval-required.component.ts
+++ b/frontend/src/app/pages/approval-required/approval-required.component.ts
@@ -2,8 +2,9 @@ import { Component, inject, type OnInit } from '@angular/core'
 import { ConfigService } from '../../services/config.service'
 import type { ConfigResponse } from '@shared/api-response/ConfigResponse'
 import { MaterialModule } from '../../material-module'
-import { RouterLink } from '@angular/router'
+import { Router, RouterLink } from '@angular/router'
 import { TranslatePipe } from '@ngx-translate/core'
+import { AuthService } from '../../services/auth.service'
 
 @Component({
   selector: 'app-approval-required',
@@ -16,8 +17,31 @@ export class ApprovalRequiredComponent implements OnInit {
   config?: ConfigResponse
 
   configService = inject(ConfigService)
+  authService = inject(AuthService)
+  router = inject(Router)
 
   async ngOnInit() {
     this.config = await this.configService.getConfig()
+  }
+
+  async tryAgain() {
+    try {
+      try {
+        const info = await this.authService.interactionExists()
+        if (info.user?.isPrivileged) {
+          await this.router.navigate(['/'])
+          return
+        }
+      } catch (_e) {
+        await this.router.navigate(['/'])
+        return
+      }
+      const result = await this.authService.interactionTryAgain()
+      if (result.location) {
+        window.location.href = result.location
+      }
+    } catch (error) {
+      console.error('Failed to try again:', error)
+    }
   }
 }

--- a/frontend/src/app/pages/approval-required/approval-required.component.ts
+++ b/frontend/src/app/pages/approval-required/approval-required.component.ts
@@ -5,6 +5,7 @@ import { MaterialModule } from '../../material-module'
 import { Router, RouterLink } from '@angular/router'
 import { TranslatePipe } from '@ngx-translate/core'
 import { AuthService } from '../../services/auth.service'
+import { SpinnerService } from '../../services/spinner.service'
 
 @Component({
   selector: 'app-approval-required',
@@ -15,33 +16,74 @@ import { AuthService } from '../../services/auth.service'
 
 export class ApprovalRequiredComponent implements OnInit {
   config?: ConfigResponse
+  canRetry = true
 
-  configService = inject(ConfigService)
-  authService = inject(AuthService)
-  router = inject(Router)
+  private configService = inject(ConfigService)
+  private authService = inject(AuthService)
+  private router = inject(Router)
+  private spinnerService = inject(SpinnerService)
 
   async ngOnInit() {
-    this.config = await this.configService.getConfig()
+    this.spinnerService.show()
+    try {
+      this.config = await this.configService.getConfig()
+      // Check if interaction exists
+      try {
+        const info = await this.authService.interactionExists()
+        // If the user is privileged now, we can attempt to retry the interaction without user trigger
+        if (info.user?.isPrivileged) {
+          try {
+            const result = await this.authService.interactionTryAgain()
+            window.location.href = result.location
+          } catch (_error) {
+            // If there's an error during the retry attempt, we cannot retry again (likely due to no lastSubmission)
+            this.canRetry = false
+            await this.router.navigate(['/'])
+          }
+        }
+      } catch (_e) {
+        // If the interaction does not exist, we cannot retry
+        this.canRetry = false
+      }
+    } catch (_e) {
+      // do nothing
+    } finally {
+      this.spinnerService.hide()
+    }
   }
 
   async tryAgain() {
+    this.spinnerService.show()
     try {
-      try {
-        const info = await this.authService.interactionExists()
-        if (info.user?.isPrivileged) {
-          await this.router.navigate(['/'])
-          return
-        }
-      } catch (_e) {
+      // Only attempt to retry if we haven't determined that retrying is not possible
+      if (!this.canRetry) {
         await this.router.navigate(['/'])
         return
       }
-      const result = await this.authService.interactionTryAgain()
-      if (result.location) {
-        window.location.href = result.location
+      // Check if interaction exists
+      try {
+        await this.authService.interactionExists()
+      } catch (_e) {
+        // If the interaction does not exist, we cannot retry
+        this.canRetry = false
+        await this.router.navigate(['/'])
+        return
       }
-    } catch (error) {
-      console.error('Failed to try again:', error)
+
+      // If we get here, the interaction exists, so we can try to retry
+      try {
+        const result = await this.authService.interactionTryAgain()
+        window.location.href = result.location
+      } catch (_error) {
+        // If there's an error during the retry attempt, we cannot retry again (likely due to no lastSubmission)
+        this.canRetry = false
+        await this.router.navigate(['/'])
+        return
+      }
+    } catch (_e) {
+      // do nothing
+    } finally {
+      this.spinnerService.hide()
     }
   }
 }

--- a/frontend/src/app/pages/approval-required/approval-required.component.ts
+++ b/frontend/src/app/pages/approval-required/approval-required.component.ts
@@ -16,7 +16,6 @@ import { SpinnerService } from '../../services/spinner.service'
 
 export class ApprovalRequiredComponent implements OnInit {
   config?: ConfigResponse
-  canRetry = true
 
   private configService = inject(ConfigService)
   private authService = inject(AuthService)
@@ -37,13 +36,12 @@ export class ApprovalRequiredComponent implements OnInit {
             window.location.href = result.location
           } catch (_error) {
             // If there's an error during the retry attempt, we cannot retry again (likely due to no lastSubmission)
-            this.canRetry = false
             await this.router.navigate(['/'])
+            return
           }
         }
       } catch (_e) {
-        // If the interaction does not exist, we cannot retry
-        this.canRetry = false
+        // If the interaction does not exist, we cannot retry, do nothing
       }
     } catch (_e) {
       // do nothing
@@ -55,17 +53,11 @@ export class ApprovalRequiredComponent implements OnInit {
   async tryAgain() {
     this.spinnerService.show()
     try {
-      // Only attempt to retry if we haven't determined that retrying is not possible
-      if (!this.canRetry) {
-        await this.router.navigate(['/'])
-        return
-      }
       // Check if interaction exists
       try {
         await this.authService.interactionExists()
       } catch (_e) {
         // If the interaction does not exist, we cannot retry
-        this.canRetry = false
         await this.router.navigate(['/'])
         return
       }
@@ -76,7 +68,6 @@ export class ApprovalRequiredComponent implements OnInit {
         window.location.href = result.location
       } catch (_error) {
         // If there's an error during the retry attempt, we cannot retry again (likely due to no lastSubmission)
-        this.canRetry = false
         await this.router.navigate(['/'])
         return
       }

--- a/frontend/src/app/pages/user-expired/user-expired.component.html
+++ b/frontend/src/app/pages/user-expired/user-expired.component.html
@@ -3,7 +3,8 @@
   <mat-card-content>
     <p style="text-align: center">{{ "user-expired.content" | translate }}</p>
     <mat-card-actions>
-      <a mat-flat-button routerLink="/">{{ "user-expired.actions.login" | translate }}</a>
+      <a mat-button routerLink="/login">{{ "user-expired.actions.login" | translate }}</a>
+      <button mat-flat-button (click)="tryAgain()">{{ "user-expired.actions.try-again" | translate }}</button>
     </mat-card-actions>
   </mat-card-content>
 </mat-card>

--- a/frontend/src/app/pages/user-expired/user-expired.component.scss
+++ b/frontend/src/app/pages/user-expired/user-expired.component.scss
@@ -1,0 +1,13 @@
+mat-card-content {
+  padding-top: 32px;
+
+  mat-card-actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+
+    > * {
+      margin-left: 16px;
+    }
+  }
+}

--- a/frontend/src/app/pages/user-expired/user-expired.component.ts
+++ b/frontend/src/app/pages/user-expired/user-expired.component.ts
@@ -2,8 +2,9 @@ import { Component, inject, type OnInit } from '@angular/core'
 import { ConfigService } from '../../services/config.service'
 import type { ConfigResponse } from '@shared/api-response/ConfigResponse'
 import { MaterialModule } from '../../material-module'
-import { RouterLink } from '@angular/router'
+import { Router, RouterLink } from '@angular/router'
 import { TranslatePipe } from '@ngx-translate/core'
+import { AuthService } from '../../services/auth.service'
 
 @Component({
   selector: 'app-user-expired',
@@ -16,8 +17,31 @@ export class UserExpiredComponent implements OnInit {
   config?: ConfigResponse
 
   configService = inject(ConfigService)
+  authService = inject(AuthService)
+  router = inject(Router)
 
   async ngOnInit() {
     this.config = await this.configService.getConfig()
+  }
+
+  async tryAgain() {
+    try {
+      try {
+        const info = await this.authService.interactionExists()
+        if (info.user?.isPrivileged) {
+          await this.router.navigate(['/'])
+          return
+        }
+      } catch (_e) {
+        await this.router.navigate(['/'])
+        return
+      }
+      const result = await this.authService.interactionTryAgain()
+      if (result.location) {
+        window.location.href = result.location
+      }
+    } catch (error) {
+      console.error('Failed to try again:', error)
+    }
   }
 }

--- a/frontend/src/app/pages/user-expired/user-expired.component.ts
+++ b/frontend/src/app/pages/user-expired/user-expired.component.ts
@@ -30,8 +30,9 @@ export class UserExpiredComponent implements OnInit {
       // Check if interaction exists
       try {
         const info = await this.authService.interactionExists()
-        // If the user is privileged now, we can attempt to retry the interaction without user trigger
-        if (info.user?.isPrivileged) {
+        // If the user is no longer expired, we can attempt to retry the interaction without user trigger
+        const isNotExpired = !info.user?.expiresAt || new Date(info.user.expiresAt).getTime() >= Date.now()
+        if (isNotExpired) {
           try {
             const result = await this.authService.interactionTryAgain()
             window.location.href = result.location

--- a/frontend/src/app/pages/user-expired/user-expired.component.ts
+++ b/frontend/src/app/pages/user-expired/user-expired.component.ts
@@ -5,6 +5,7 @@ import { MaterialModule } from '../../material-module'
 import { Router, RouterLink } from '@angular/router'
 import { TranslatePipe } from '@ngx-translate/core'
 import { AuthService } from '../../services/auth.service'
+import { SpinnerService } from '../../services/spinner.service'
 
 @Component({
   selector: 'app-user-expired',
@@ -15,33 +16,74 @@ import { AuthService } from '../../services/auth.service'
 
 export class UserExpiredComponent implements OnInit {
   config?: ConfigResponse
+  canRetry = true
 
-  configService = inject(ConfigService)
-  authService = inject(AuthService)
-  router = inject(Router)
+  private configService = inject(ConfigService)
+  private authService = inject(AuthService)
+  private router = inject(Router)
+  private spinnerService = inject(SpinnerService)
 
   async ngOnInit() {
-    this.config = await this.configService.getConfig()
+    this.spinnerService.show()
+    try {
+      this.config = await this.configService.getConfig()
+      // Check if interaction exists
+      try {
+        const info = await this.authService.interactionExists()
+        // If the user is privileged now, we can attempt to retry the interaction without user trigger
+        if (info.user?.isPrivileged) {
+          try {
+            const result = await this.authService.interactionTryAgain()
+            window.location.href = result.location
+          } catch (_error) {
+            // If there's an error during the retry attempt, we cannot retry again (likely due to no lastSubmission)
+            this.canRetry = false
+            await this.router.navigate(['/'])
+          }
+        }
+      } catch (_e) {
+        // If the interaction does not exist, we cannot retry
+        this.canRetry = false
+      }
+    } catch (_e) {
+      // do nothing
+    } finally {
+      this.spinnerService.hide()
+    }
   }
 
   async tryAgain() {
+    this.spinnerService.show()
     try {
-      try {
-        const info = await this.authService.interactionExists()
-        if (info.user?.isPrivileged) {
-          await this.router.navigate(['/'])
-          return
-        }
-      } catch (_e) {
+      // Only attempt to retry if we haven't determined that retrying is not possible
+      if (!this.canRetry) {
         await this.router.navigate(['/'])
         return
       }
-      const result = await this.authService.interactionTryAgain()
-      if (result.location) {
-        window.location.href = result.location
+      // Check if interaction exists
+      try {
+        await this.authService.interactionExists()
+      } catch (_e) {
+        // If the interaction does not exist, we cannot retry
+        this.canRetry = false
+        await this.router.navigate(['/'])
+        return
       }
-    } catch (error) {
-      console.error('Failed to try again:', error)
+
+      // If we get here, the interaction exists, so we can try to retry
+      try {
+        const result = await this.authService.interactionTryAgain()
+        window.location.href = result.location
+      } catch (_error) {
+        // If there's an error during the retry attempt, we cannot retry again (likely due to no lastSubmission)
+        this.canRetry = false
+        await this.router.navigate(['/'])
+        return
+      }
+    } catch (_e) {
+      // do nothing
+    } finally {
+      this.spinnerService.hide()
     }
   }
 }

--- a/frontend/src/app/pages/user-expired/user-expired.component.ts
+++ b/frontend/src/app/pages/user-expired/user-expired.component.ts
@@ -16,7 +16,6 @@ import { SpinnerService } from '../../services/spinner.service'
 
 export class UserExpiredComponent implements OnInit {
   config?: ConfigResponse
-  canRetry = true
 
   private configService = inject(ConfigService)
   private authService = inject(AuthService)
@@ -38,13 +37,12 @@ export class UserExpiredComponent implements OnInit {
             window.location.href = result.location
           } catch (_error) {
             // If there's an error during the retry attempt, we cannot retry again (likely due to no lastSubmission)
-            this.canRetry = false
             await this.router.navigate(['/'])
+            return
           }
         }
       } catch (_e) {
-        // If the interaction does not exist, we cannot retry
-        this.canRetry = false
+        // If the interaction does not exist, we cannot retry, do nothing
       }
     } catch (_e) {
       // do nothing
@@ -56,17 +54,11 @@ export class UserExpiredComponent implements OnInit {
   async tryAgain() {
     this.spinnerService.show()
     try {
-      // Only attempt to retry if we haven't determined that retrying is not possible
-      if (!this.canRetry) {
-        await this.router.navigate(['/'])
-        return
-      }
       // Check if interaction exists
       try {
         await this.authService.interactionExists()
       } catch (_e) {
         // If the interaction does not exist, we cannot retry
-        this.canRetry = false
         await this.router.navigate(['/'])
         return
       }
@@ -77,7 +69,6 @@ export class UserExpiredComponent implements OnInit {
         window.location.href = result.location
       } catch (_error) {
         // If there's an error during the retry attempt, we cannot retry again (likely due to no lastSubmission)
-        this.canRetry = false
         await this.router.navigate(['/'])
         return
       }

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -30,6 +30,10 @@ export class AuthService {
     return firstValueFrom(this.http.get<InteractionInfo>('/api/interaction/exists'))
   }
 
+  async interactionTryAgain() {
+    return firstValueFrom(this.http.post<Redirect>('/api/interaction/try-again', {}))
+  }
+
   async createInteraction(defaultRedir: boolean = false) {
     try {
       await firstValueFrom(this.http.get<null>(oidcLoginPath(getCurrentHost(), defaultRedir, 'login'), {

--- a/server/routes/interaction.ts
+++ b/server/routes/interaction.ts
@@ -77,7 +77,6 @@ router.get('/', async (req, res) => {
   }
   const { uid, prompt, params } = interaction
 
-  const session = await getSession(req, res)
   const user = req.user
 
   logger({
@@ -96,20 +95,9 @@ router.get('/', async (req, res) => {
   if (prompt.name === 'login') {
     // Check for prompt reasons that cause special redirects
     if (prompt.reasons.includes('user_not_approved')) {
-      // User is not approved, destroy their session/interaction so they can re-attempt login
-      await interaction.destroy()
-      if (session) {
-        await session.destroy()
-      }
       res.redirect(`${appConfig.APP_URL}/${REDIRECT_PATHS.APPROVAL_REQUIRED}`)
       return
     } else if (prompt.reasons.includes('user_expired')) {
-      // User is expired, destroy their session/interaction so they can re-attempt login
-      // User is not approved, destroy their session/interaction so they can re-attempt login
-      await interaction.destroy()
-      if (session) {
-        await session.destroy()
-      }
       res.redirect(`${appConfig.APP_URL}/${REDIRECT_PATHS.USER_EXPIRED}`)
       return
     } else if (prompt.reasons.includes('user_mfa_required')) {
@@ -222,6 +210,22 @@ router.get('/exists', async (req, res) => {
   }
 
   res.send(info)
+})
+
+router.post('/try-again', async (req, res) => {
+  const interaction = await getInteractionDetails(req, res)
+  if (!interaction?.lastSubmission) {
+    res.sendStatus(404)
+    return
+  }
+
+  const redir: Redirect = {
+    location: await provider.interactionResult(req, res, interaction.lastSubmission, {
+      mergeWithLastSubmission: true,
+    }),
+  }
+
+  res.send(redir)
 })
 
 router.delete('/current', async (req, res) => {

--- a/server/routes/interaction.ts
+++ b/server/routes/interaction.ts
@@ -204,9 +204,13 @@ router.get('/exists', async (req, res) => {
 
   const info: InteractionInfo = {
     successRedirect: redir,
-    user: {
-      isPrivileged: req.user?.isPrivileged,
-    },
+    user: req.user
+      ? {
+          isPrivileged: req.user.isPrivileged,
+          expiresAt: req.user.expiresAt,
+          approved: req.user.approved,
+        }
+      : undefined,
   }
 
   res.send(info)

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -39,6 +39,8 @@ userRouter.get('/me',
       emailVerified: user.emailVerified,
       hasTotp: user.hasTotp,
       hasPasskeys: user.hasPasskeys,
+      expiresAt: user.expiresAt,
+      approved: user.approved,
 
       amr: user.amr,
       canLogin: user.canLogin,

--- a/shared/api-response/InteractionInfo.ts
+++ b/shared/api-response/InteractionInfo.ts
@@ -3,5 +3,5 @@ import type { CurrentUserDetails } from './UserDetails'
 
 export type InteractionInfo = {
   successRedirect: Redirect | null
-  user?: Partial<Pick<CurrentUserDetails, 'isPrivileged'>>
+  user?: Pick<CurrentUserDetails, 'isPrivileged' | 'expiresAt' | 'approved'>
 }

--- a/shared/api-response/Redirect.ts
+++ b/shared/api-response/Redirect.ts
@@ -1,5 +1,5 @@
 export type Redirect = {
-  success: boolean
+  success?: boolean
   location: string
   message?: string
 }

--- a/shared/api-response/UserDetails.ts
+++ b/shared/api-response/UserDetails.ts
@@ -33,7 +33,7 @@ export type CurrentUserPrivateDetails = UserDetails & UserSessionInfo
 // so should not contain anything that could be used to elevate privileges or identify the user
 export type CurrentUserDetails = Pick<
   UserDetails,
-  'id' | 'isAdmin' | 'hasTotp' | 'hasPasskeys' | 'hasEmail' | 'emailVerified'>
+  'id' | 'isAdmin' | 'hasTotp' | 'hasPasskeys' | 'hasEmail' | 'emailVerified' | 'expiresAt' | 'approved'>
   & UserSessionInfo & {
     // Guard, these fields should not be sent to an unprivileged frontend
     username?: undefined


### PR DESCRIPTION
## Description
- Fix Issue Where Self Registered Users Are Not Being Redirected to Default Redirect When Approved
- Fix header logo DEFAULT_REDIRECT not working if APP_URL has a sub-path.
- No longer delete sessions of unapproved or expired users, so condition can be changed and session continued.

## Related Tickets & Documents
#442
