### PR TITLE
feat(i18n): add Estonian (et-EE) translation

### DIFF
--- a/frontend/public/i18n/et-EE.json
+++ b/frontend/public/i18n/et-EE.json
@@ -1,0 +1,589 @@
+{
+  "login": {
+    "password": {
+      "label": "Parool"
+    },
+    "username": {
+      "label": "Kasutajanimi või e-post"
+    },
+    "forgot-password": "Unustasid parooli?",
+    "remember-me": "Jäta mind meelde",
+    "actions": {
+      "login": "Logi sisse",
+      "sign-up": "Registreeru"
+    },
+    "title": "Sisselogimine"
+  },
+  "contact-us": {
+    "actions": {
+      "label": "Kontakt"
+    }
+  },
+  "app": {
+    "loading": "Laadimine...",
+    "navigation": {
+      "profile": "Profiil",
+      "admin": {
+        "title": "Admin",
+        "oidc-apps": "OIDC rakendused",
+        "proxyauth-domains": "ProxyAuth domeenid",
+        "users": "Kasutajad",
+        "groups": "Grupid",
+        "invitations": "Kutsed",
+        "password-resets": "Parooli lähtestamised",
+        "sent-mail": "Saadetud e-kirjad"
+      },
+      "logout": "Logi välja"
+    }
+  },
+  "passkey-title": "Pääsuvõti",
+  "passkey-dialog": {
+    "title": "Kas lubada {{platformName}}?",
+    "actions": {
+      "passkey": "Luba {{platformName}}"
+    }
+  },
+  "mfa": {
+    "actions": {
+      "use-passkey": "Kasuta {{platformName}}",
+      "register-passkey": "Registreeri pääsuvõti",
+      "back": "Tagasi"
+    },
+    "title": "Nõutud on mitmeastmeline autentimine"
+  },
+  "registration": {
+    "actions": {
+      "passkey-sign-up": "Registreeru kasutades {{platformName}}",
+      "sign-up": "Registreeru",
+      "login": "Logi sisse"
+    },
+    "title": {
+      "accept-invitation": "Võta kutse vastu",
+      "sign-up": "Registreeru"
+    },
+    "username": {
+      "label": "Kasutajanimi"
+    },
+    "email": {
+      "label": "E-post"
+    },
+    "name": {
+      "label": "Nimi"
+    }
+  },
+  "reset-password": {
+    "actions": {
+      "enable-passkey": "Luba {{platformName}}",
+      "reset-password": "Lähtesta parool"
+    },
+    "title": "Parooli lähtestamine"
+  },
+  "approval-required": {
+    "content": "Sinu konto vajab enne sisselogimist heakskiitu. Palun oota või võta abi saamiseks ühendust administraatoriga.",
+    "title": "Vajalik on heakskiit",
+    "actions": {
+      "login": "Logi sisse",
+      "try-again": "Proovi uuesti"
+    }
+  },
+  "forbidden": {
+    "title": "Juurdepääs keelatud",
+    "content": "Sul puudub õigus selle ressursi kasutamiseks.",
+    "actions": {
+      "back": "Tagasi"
+    }
+  },
+  "consent": {
+    "actions": {
+      "sign-in": "Logi sisse"
+    },
+    "info": {
+      "sign-into-question": "Kas soovid sisse logida <br /> <h2>{{destination}}</h2>",
+      "post-signin-redir-notice": "Pärast sisselogimist suunatakse sind aadressile <b>{{redirect}}</b>"
+    },
+    "title": "Kinnita"
+  },
+  "forgot-password": {
+    "username": {
+      "label": "E-post või kasutajanimi"
+    },
+    "actions": {
+      "send": "Saada",
+      "send-again": "Saada uuesti",
+      "create-again": "Loo uuesti",
+      "create": "Loo"
+    },
+    "title": "Unustasid parooli?"
+  },
+  "form-errors": {
+    "required": "Kohustuslik.",
+    "min": "Peab olema vähemalt {{min}}.",
+    "max": "Ei tohi olla suurem kui {{max}}.",
+    "minLength": "Peab olema vähemalt {{requiredLength}} tähemärki pikk.",
+    "maxLength": "Peab olema lühem kui {{requiredLength}} tähemärki.",
+    "email": "Vigane e-posti aadress.",
+    "default": "Vigane väärtus.",
+    "alpha-num-underscore-only": "Lubatud on ainult A-Z, 0-9 ja _"
+  },
+  "logout": {
+    "title": "Logi välja",
+    "info": {
+      "logout-question": "Kas soovid välja logida?"
+    },
+    "actions": {
+      "yes": "Jah",
+      "back": "Tagasi",
+      "no": "Ei"
+    }
+  },
+  "page-not-found": {
+    "title": "Lehte ei leitud",
+    "": {
+      "actions": {
+        "go-home": "Avalehele"
+      }
+    }
+  },
+  "verify-email": {
+    "verify": {
+      "title": {
+        "verifying-email": "E-posti kinnitamine...",
+        "email-could-not-be-verified": "E-posti ei õnnestunud kinnitada",
+        "sending-new-verification": "Uue kinnituse saatmine...",
+        "email-verification-could-not-be-sent": "E-posti kinnitust ei õnnestunud saata"
+      },
+      "actions": {
+        "send-again": "Saada uuesti"
+      }
+    },
+    "verify-sent": {
+      "title": {
+        "verification-email-sent": "Kinnituskiri saadetud",
+        "email-verification-required": "Nõutud on e-posti kinnitamine"
+      },
+      "actions": {
+        "logout": "Logi välja",
+        "send-again": "Saada uuesti",
+        "send-verification": "Saada kinnitus"
+      },
+      "email": {
+        "label": "E-post"
+      }
+    }
+  },
+  "settings": {
+    "title": "Seaded",
+    "sections": {
+      "profile": {
+        "title": "Profiil",
+        "username": {
+          "label": "Kasutajanimi"
+        },
+        "name": {
+          "label": "Nimi"
+        },
+        "actions": {
+          "submit": {
+            "label": "Uuenda profiili"
+          }
+        },
+        "email": {
+          "label": "E-post",
+          "actions": {
+            "submit": {
+              "label": "Uuenda e-posti"
+            }
+          }
+        }
+      },
+      "security": {
+        "title": "Turvalisus",
+        "password": {
+          "set": {
+            "label": "Määra parool"
+          },
+          "change": {
+            "label": "Muuda parooli"
+          }
+        },
+        "passkeys": {
+          "title": "Pääsuvõtmed",
+          "noPasskeys": "Sul pole registreeritud pääsuvõtmeid.",
+          "register": {
+            "label": "Registreeri pääsuvõti"
+          },
+          "manage": {
+            "title": "Halda pääsuvõtmeid"
+          },
+          "actions": {
+            "edit": {
+              "tooltip": "Muuda"
+            },
+            "delete": {
+              "tooltip": "Kustuta"
+            }
+          }
+        },
+        "mfa": {
+          "title": "Mitmeastmeline autentimine",
+          "status": {
+            "enabled": "Mitmeastmeline autentimine on lubatud.",
+            "disabled": "Mitmeastmeline autentimine ei ole lubatud."
+          },
+          "authenticators": {
+            "has": "Sul on vähemalt üks registreeritud autentimisrakendus.",
+            "none": "Sul pole registreeritud autentimisrakendusi."
+          },
+          "add": {
+            "label": "Lisa autentimisrakendus"
+          },
+          "enable": {
+            "label": "Luba MFA"
+          }
+        }
+      },
+      "account": {
+        "title": "Konto",
+        "removePassword": {
+          "label": "Eemalda parool",
+          "tooltip": {
+            "noPassword": "Sul pole parooli, mida eemaldada",
+            "noPasskeys": "Sul pole ühtegi pääsuvõtit"
+          }
+        },
+        "removeAllPasskeys": {
+          "label": "Eemalda kõik pääsuvõtmed",
+          "tooltip": {
+            "noPasskeys": "Sul pole pääsuvõtmeid, mida eemaldada",
+            "noPassword": "Sul pole parooli"
+          }
+        },
+        "disableMfa": {
+          "label": "Keela MFA"
+        },
+        "removeAuthenticators": {
+          "label": "Eemalda autentimisrakendused"
+        },
+        "deleteAccount": {
+          "label": "Kustuta konto"
+        }
+      }
+    }
+  },
+  "admin": {
+    "common": {
+      "actions": {
+        "edit": "Muuda",
+        "delete": "Kustuta",
+        "update": "Uuenda",
+        "create": "Loo",
+        "view": "Vaata",
+        "open": "Ava",
+        "remove": "Eemalda"
+      },
+      "labels": {
+        "mfa-required": "MFA nõutud",
+        "email-verified": "E-post kinnitatud",
+        "approved": "Kinnitatud"
+      },
+      "messages": {
+        "all-users-have-access": "Gruppe pole, juurdepääs on KÕIGIL kasutajatel."
+      }
+    },
+    "users": {
+      "empty-state": "Kasutajaid pole.",
+      "actions": {
+        "select": "Vali",
+        "approve": "Kinnita"
+      },
+      "labels": {
+        "search": "Otsi"
+      }
+    },
+    "user": {
+      "title": "Uuenda kasutajat",
+      "labels": {
+        "username": "Kasutajanimi",
+        "name": "Nimi",
+        "email": "E-post",
+        "add-group": "Lisa grupp",
+        "security-groups": "Turvagrupid:",
+        "user-expiration-date": "Juurdepääsu aegumiskuupäev",
+        "user-expiration-time": "Juurdepääsu aegumisaeg"
+      },
+      "actions": {
+        "sign-out": "Logi välja"
+      },
+      "tooltips": {
+        "remove": "Eemalda",
+        "open": "Ava"
+      }
+    },
+    "clients": {
+      "empty-state": "OIDC rakendusi pole.",
+      "actions": {
+        "create": "Loo OIDC rakendus"
+      }
+    },
+    "client": {
+      "title": "OIDC rakendus",
+      "labels": {
+        "name": "Nimi",
+        "home-page-url": "Avalehe URL",
+        "logo-url": "Logo URL",
+        "add-group": "Lisa grupp",
+        "client-id": "Kliendi ID",
+        "auth-method": "Autentimismeetod",
+        "client-secret": "Kliendi saladus",
+        "redirect-url": "Uus ümbersuunamise URL",
+        "response-types": "Vastuse tüübid",
+        "grant-types": "Loa tüübid",
+        "postlogout-url": "Väljalogimisjärgne URL",
+        "allowed-groups": "Lubatud grupid:",
+        "redirect-urls": "Ümbersuunamise URL-id:"
+      },
+      "hints": {
+        "pkce-required": "Selle autentimismeetodiga on PKCE nõutud.",
+        "not-required": "Praeguse autentimismeetodi puhul pole nõutud.",
+        "postlogout-redirect": "Lubatud väljalogimisjärgne ümbersuunamise URL kliendi algatatud väljalogimisel."
+      },
+      "checkboxes": {
+        "skip-consent": "Jäta nõusolek vahele",
+        "mfa-required": "MFA nõutud"
+      },
+      "tooltips": {
+        "skip-consent": "Jäta selle rakenduse puhul kasutaja kinnitus vahele.",
+        "mfa-required": "Kasutajad peavad selle rakenduse kasutamiseks kasutama MFA-d.",
+        "copy-client-id": "Kopeeri kliendi ID",
+        "copy-secret": "Kopeeri saladus"
+      },
+      "messages": {
+        "client-id-copied": "Kliendi ID kopeeriti lõikelauale.",
+        "secret-copied": "Saladus kopeeriti lõikelauale."
+      }
+    },
+    "domains": {
+      "empty-state": "Domeene pole.",
+      "actions": {
+        "create": "Loo ProxyAuth domeen"
+      }
+    },
+    "domain": {
+      "title": "ProxyAuth domeen",
+      "labels": {
+        "domain": "Domeen",
+        "max-session-length": "Sessiooni maksimaalne vanus (minutites)",
+        "add-group": "Lisa grupp",
+        "allowed-groups": "Lubatud grupid:"
+      },
+      "placeholders": {
+        "domain": "nt *.sinu.domeen.com/path/"
+      },
+      "sections": {
+        "domain-help": "Domeeni abi"
+      },
+      "hints": {
+        "no-re-auth": "Tühi tähendab, et taasautentimist pole vaja."
+      },
+      "help-text": {
+        "0": "Domeen ei tohiks sisaldada protokolli, võib sisaldada teed ja porti ning toetab metamärke (*) mis tahes positsioonil.",
+        "1": "<b>example.domain.com/api/alive</b> kontrollib juurdepääsu ainult ühele lõpp-punktile.",
+        "2": "<b>example.domain.com/api/*</b> kontrollib juurdepääsu kõigile /api all olevatele lõpp-punktidele."
+      }
+    },
+    "password-resets": {
+      "labels": {
+        "create-link": "Loo parooli lähtestamise link"
+      },
+      "tooltips": {
+        "send-email": "Saada e-kiri aadressile {{email}}",
+        "copy-link": "Kopeeri link",
+        "delete": "Kustuta"
+      },
+      "messages": {
+        "link-copied": "Lähtestamise link kopeeriti lõikelauale."
+      }
+    },
+    "emails": {
+      "empty-state": "Saadetud e-kirju pole.",
+      "actions": {
+        "send-test": "Saada testkiri"
+      },
+      "tooltips": {
+        "preview": "Eelvaade",
+        "view-user": "Vaata kasutajat"
+      }
+    },
+    "groups": {
+      "empty-state": "Gruppe pole.",
+      "actions": {
+        "create": "Loo grupp"
+      }
+    },
+    "group": {
+      "title": "Grupp",
+      "labels": {
+        "name": "Nimi",
+        "add-user": "Lisa kasutaja",
+        "users": "Kasutajad:"
+      },
+      "checkboxes": {
+        "mfa-required": "MFA nõutud",
+        "auto-assign": "Automaatne määramine"
+      }
+    },
+    "invitations": {
+      "empty-state": "Kutseid pole.",
+      "actions": {
+        "create": "Loo kutse"
+      }
+    },
+    "invitation": {
+      "title": "Kutse",
+      "labels": {
+        "invite-link": "Kutse link",
+        "username": "Kasutajanimi",
+        "email": "E-post",
+        "name": "Nimi",
+        "add-group": "Lisa grupp",
+        "security-groups": "Turvagrupid:",
+        "user-expiration-date": "Juurdepääsu aegumiskuupäev",
+        "user-expiration-time": "Juurdepääsu aegumisaeg"
+      },
+      "tooltips": {
+        "copy-invite-link": "Kopeeri kutse link",
+        "unsaved-changes": "Sul on salvestamata muudatusi.",
+        "send-to": "Saada kutse aadressile: {{email}}"
+      },
+      "messages": {
+        "link-copied": "Kutse link kopeeriti lõikelauale.",
+        "email-not-verified": "Kutse linki ei saa e-postiga saata, e-posti ühendus pole kinnitatud.",
+        "no-email": "Kutse linki ei saa e-postiga saata, kutse ei sisalda e-posti aadressi."
+      },
+      "actions": {
+        "send": "Saada kutse"
+      },
+      "checkboxes": {
+        "email-verified": "E-post kinnitatud"
+      }
+    }
+  },
+  "components": {
+    "header": {
+      "actions": {
+        "login": "Logi sisse"
+      }
+    },
+    "copy-field": {
+      "messages": {
+        "copied": "{{label}} kopeeriti lõikelauale."
+      }
+    },
+    "oidc-info": {
+      "title": "OIDC teave",
+      "labels": {
+        "issuer": "OIDC Issuer lõpp-punkt",
+        "well-known": "Well-Known lõpp-punkt",
+        "authorization": "Autoriseerimise lõpp-punkt",
+        "token": "Tokeni lõpp-punkt",
+        "userinfo": "UserInfo lõpp-punkt",
+        "logout": "Väljalogimise lõpp-punkt",
+        "jwks": "JWKs lõpp-punkt"
+      },
+      "actions": {
+        "all-info": "Kogu teave"
+      }
+    },
+    "password-input": {
+      "labels": {
+        "new-password": "Uus parool",
+        "old-password": "Vana parool",
+        "confirm-password": "Kinnita parool"
+      }
+    },
+    "totp-input": {
+      "title": "See lubab sinu kontol mitmeastmelise autentimise.",
+      "labels": {
+        "show-secret": "Näita salavõtit"
+      },
+      "text": {
+        "qrcode-instruction": "Skanni QR-kood või sisesta salavõti oma autentimisrakendusse",
+        "then": "seejärel",
+        "enter-token": "Jätkamiseks sisesta autentimisrakendusest kood"
+      }
+    },
+    "theme-toggle": {
+      "options": {
+        "system": "Süsteem",
+        "light": "Hele",
+        "dark": "Tume"
+      }
+    },
+    "email-input": {
+      "message": {
+        "default": "Palun sisesta allpool e-posti aadress."
+      },
+      "actions": {
+        "cancel": {
+          "label": "Tühista"
+        },
+        "confirm": {
+          "label": "Kinnita"
+        }
+      }
+    },
+    "totp-register": {
+      "title": "Lisa autentimisrakendus",
+      "actions": {
+        "cancel": {
+          "label": "Tühista"
+        }
+      }
+    },
+    "passkey-edit": {
+      "title": "Muuda pääsuvõtme nime",
+      "message": {
+        "default": "Sisesta sellele pääsuvõtmele nimi."
+      },
+      "actions": {
+        "cancel": {
+          "label": "Tühista"
+        },
+        "save": {
+          "label": "Salvesta"
+        }
+      }
+    },
+    "confirm": {
+      "instructions": "Kinnitamiseks sisesta allolevasse kasti <b>{{requiredText}}</b>.",
+      "actions": {
+        "cancel": {
+          "label": "Tühista"
+        },
+        "confirm": {
+          "label": "Kinnita"
+        }
+      }
+    }
+  },
+  "user-expired": {
+    "title": "Konto juurdepääs aegunud",
+    "content": "Sinu konto juurdepääs on aegunud, juurdepääsu pikendamiseks võta palun ühendust administraatoriga.",
+    "actions": {
+      "login": "Logi sisse",
+      "try-again": "Proovi uuesti"
+    }
+  },
+  "passkey-name": {
+    "title": "Pääsuvõtme nimi",
+    "prompt": "Kas määrata uuele pääsuvõtmele nimi?",
+    "actions": {
+      "skip": {
+        "label": "Jäta vahele"
+      },
+      "save": {
+        "label": "Salvesta"
+      }
+    }
+  }
+}

--- a/frontend/public/locales.json
+++ b/frontend/public/locales.json
@@ -1,5 +1,6 @@
 [
   { "code": "en-US", "display": "English" },
   { "code": "zh-CN", "display": "中文" },
-  { "code": "fr-FR", "display": "Français" }
+  { "code": "fr-FR", "display": "Français" },
+  { "code": "et-EE", "display": "Eesti" }
 ]


### PR DESCRIPTION
## Description
Adds a complete Estonian (et-EE) translation:
- New `frontend/public/i18n/et-EE.json` — all 257 keys translated from `en-US.json`.
- Registers `et-EE` ("Eesti") in `frontend/public/locales.json`

## Related Tickets & Documents
Relates to #63, #280.

Happy to contribute to such a promising project.
