### PR TITLE
Do not escape values in text emails

### DIFF
--- a/default_email_templates/admin_notification/text.default.ejs
+++ b/default_email_templates/admin_notification/text.default.ejs
@@ -1,4 +1,4 @@
 Admin Notifications
-As an administrator of <%= locals.app_title %>, you have the following new notifications from <%= locals.app_url %>:
+As an administrator of <%- locals.app_title %>, you have the following new notifications from <%- locals.app_url %>:
 There are user(s) awaiting newly awaiting approval or deletion.
-<%= locals.users_url %>
+<%- locals.users_url %>

--- a/default_email_templates/approved/text.default.ejs
+++ b/default_email_templates/approved/text.default.ejs
@@ -1,3 +1,3 @@
 Your Access is Approved
-<%= locals.name ? locals.name+', ' : '' %>you can now access <%= locals.app_title %> at
-<%= locals.default_url %>
+<%- locals.name ? locals.name+', ' : '' %>you can now access <%- locals.app_title %> at
+<%- locals.default_url %>

--- a/default_email_templates/email_verification/text.default.ejs
+++ b/default_email_templates/email_verification/text.default.ejs
@@ -1,6 +1,6 @@
 Confirm your Email Address
-At <%= locals.app_title %>
-<%= locals.name ? locals.name+', ' : '' %>please verify your email by following the link below.
-<%= locals.verification_url %>
+At <%- locals.app_title %>
+<%- locals.name ? locals.name+', ' : '' %>please verify your email by following the link below.
+<%- locals.verification_url %>
 This email verification link is valid for 12 hours.
-You received this email because you set or changed your email at <%= locals.app_title %>. If you didn't, please ignore this notification and do not click any buttons or links.
+You received this email because you set or changed your email at <%- locals.app_title %>. If you didn't, please ignore this notification and do not click any buttons or links.

--- a/default_email_templates/invitation/text.default.ejs
+++ b/default_email_templates/invitation/text.default.ejs
@@ -1,4 +1,4 @@
 You Are Invited To
-<%= locals.app_title %>
-<%= locals.name ? locals.name+', ' : '' %>please accept your invitation by following the link below.
-<%= locals.invitation_url %>
+<%- locals.app_title %>
+<%- locals.name ? locals.name+', ' : '' %>please accept your invitation by following the link below.
+<%- locals.invitation_url %>

--- a/default_email_templates/reset_password/text.default.ejs
+++ b/default_email_templates/reset_password/text.default.ejs
@@ -1,6 +1,6 @@
 Reset Your Password
-At <%= locals.app_title %>
-<%= locals.name ? locals.name+', ' : '' %>you can reset your password by following the link below.
-<%= locals.reset_url %>
+At <%- locals.app_title %>
+<%- locals.name ? locals.name+', ' : '' %>you can reset your password by following the link below.
+<%- locals.reset_url %>
 This password reset is only valid for 2 hours.
-You received this email because you requested a password reset at <%= locals.app_title %>, if you didn't, please ignore this email and do not click any buttons or links.
+You received this email because you requested a password reset at <%- locals.app_title %>, if you didn't, please ignore this email and do not click any buttons or links.

--- a/default_email_templates/test_notification/text.default.ejs
+++ b/default_email_templates/test_notification/text.default.ejs
@@ -1,3 +1,3 @@
 Test Notification
-From <%= locals.app_title %>
+From <%- locals.app_title %>
 You received this notification as a test.


### PR DESCRIPTION
## Description
In text emails the values should not be xml escaped. At least in the invitation emails this causes broken links, because the `&` in the url is escaped as `&amp;`. 

## AI Usage
There was no AI used for this commit.

## Screenshots
No visual changes.