### PR TITLE
Improve TOTP autofill hints

### DIFF
--- a/frontend/src/app/components/totp-input/totp-input.component.html
+++ b/frontend/src/app/components/totp-input/totp-input.component.html
@@ -42,7 +42,11 @@
       id="totp_input"
       matInput
       type="text"
+      name="totp"
       inputmode="numeric"
+      autocomplete="one-time-code"
+      maxlength="6"
+      pattern="[0-9]*"
       [disabled]="disabled()"
       (input)="onCodeInput($event)"
       class="totp-digit-input"


### PR DESCRIPTION
Adds standard OTP field hints to the TOTP input so browsers and password managers can identify it as a one-time-code field. Related to #484.

Checked:
- npm run build:dev (frontend)
- npm run lint

AI disclosure: I used Codex to make this small edit.