### PR TITLE
Fix spinner timer races for fast requests

### DIFF
--- a/frontend/src/app/services/spinner.service.ts
+++ b/frontend/src/app/services/spinner.service.ts
@@ -8,19 +8,39 @@ export class SpinnerService {
   private ngxSpinnerService = inject(NgxSpinnerService)
 
   private count = 0
+  private showTimeout?: ReturnType<typeof setTimeout>
+  private hideTimeout?: ReturnType<typeof setTimeout>
 
   show(immediate: boolean = false) {
-    this.count++
-    setTimeout(() => {
+    this.count = this.count + 1
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout)
+      this.hideTimeout = undefined
+    }
+    if (this.showTimeout) {
+      clearTimeout(this.showTimeout)
+    }
+    this.showTimeout = setTimeout(() => {
+      this.showTimeout = undefined
       this.checkStatusShow()
     }, immediate ? 0 : 500) // Do not show the spinner if the operation is very fast
   }
 
   hide() {
-    this.count--
-    setTimeout(() => {
-      this.checkStatusHide()
-    }, 2000) // Keep the spinner visible for a bit to avoid flickering
+    this.count = Math.max(this.count - 1, 0)
+    if (this.showTimeout) {
+      clearTimeout(this.showTimeout)
+      this.showTimeout = undefined
+    }
+    if (this.count <= 0) {
+      if (this.hideTimeout) {
+        clearTimeout(this.hideTimeout)
+      }
+      this.hideTimeout = setTimeout(() => {
+        this.hideTimeout = undefined
+        this.checkStatusHide()
+      }, 2000) // Keep the spinner visible for a bit to avoid flickering
+    }
   }
 
   private checkStatusShow() {


### PR DESCRIPTION
## Summary
- Cancel pending spinner show/hide timers whenever request state changes.
- Prevent the loading overlay from flashing briefly on operations that finish quickly.
- Keep the existing 2s hide delay behavior so real long-running operations still avoid flicker.

Validation:
- npm run lint (passes with pre-existing repository warnings only)
- frontend npm run build:dev (successful)
