### PR TITLE
fix(logout): prevent duplicate logout submits

### DIFF
--- a/frontend/src/app/pages/logout/logout.component.html
+++ b/frontend/src/app/pages/logout/logout.component.html
@@ -1,7 +1,7 @@
 <h1>{{ "logout.title" | translate }}</h1>
 <mat-card class="form-card">
   <mat-card-content>
-    <form autocomplete="off" [action]="baseHref + '/oidc/session/end/confirm'" method="post" (submit)="onSubmit($event)">
+    <form autocomplete="off" [action]="baseHref + '/oidc/session/end/confirm'" method="post">
       <!-- TODO: Display OIDC App name/id if provided -->
       @if (privUser) {
         <h2>{{ privUser.name ?? privUser.username }}</h2>
@@ -9,15 +9,15 @@
       <p>{{ "logout.info.logout-question" | translate }}</p>
       <input type="hidden" name="xsrf" [value]="challenge" />
       <mat-card-actions>
-        <button mat-flat-button autofocus="" [disabled]="!challenge || isSubmitting" type="submit" value="yes" name="logout">
+        <button mat-flat-button autofocus="" [disabled]="!challenge" type="submit" value="yes" name="logout">
           {{ "logout.actions.yes" | translate }}
         </button>
         @if (history.length) {
-          <button mat-button type="button" (click)="history.back()" [disabled]="isSubmitting">
+          <button mat-button type="button" (click)="history.back()">
             {{ "logout.actions.back" | translate }}
           </button>
         } @else {
-          <button mat-button type="submit" [disabled]="isSubmitting">{{ "logout.actions.no" | translate }}</button>
+          <button mat-button type="submit">{{ "logout.actions.no" | translate }}</button>
         }
       </mat-card-actions>
     </form>

--- a/frontend/src/app/pages/logout/logout.component.html
+++ b/frontend/src/app/pages/logout/logout.component.html
@@ -1,7 +1,7 @@
 <h1>{{ "logout.title" | translate }}</h1>
 <mat-card class="form-card">
   <mat-card-content>
-    <form autocomplete="off" [action]="baseHref + '/oidc/session/end/confirm'" method="post">
+    <form autocomplete="off" [action]="baseHref + '/oidc/session/end/confirm'" method="post" (submit)="onSubmit($event)">
       <!-- TODO: Display OIDC App name/id if provided -->
       @if (privUser) {
         <h2>{{ privUser.name ?? privUser.username }}</h2>
@@ -9,13 +9,15 @@
       <p>{{ "logout.info.logout-question" | translate }}</p>
       <input type="hidden" name="xsrf" [value]="challenge" />
       <mat-card-actions>
-        <button mat-flat-button autofocus="" [disabled]="!challenge" type="submit" value="yes" name="logout">
+        <button mat-flat-button autofocus="" [disabled]="!challenge || isSubmitting" type="submit" value="yes" name="logout">
           {{ "logout.actions.yes" | translate }}
         </button>
         @if (history.length) {
-          <button mat-button type="button" (click)="history.back()">{{ "logout.actions.back" | translate }}</button>
+          <button mat-button type="button" (click)="history.back()" [disabled]="isSubmitting">
+            {{ "logout.actions.back" | translate }}
+          </button>
         } @else {
-          <button mat-button type="submit">{{ "logout.actions.no" | translate }}</button>
+          <button mat-button type="submit" [disabled]="isSubmitting">{{ "logout.actions.no" | translate }}</button>
         }
       </mat-card-actions>
     </form>

--- a/frontend/src/app/pages/logout/logout.component.ts
+++ b/frontend/src/app/pages/logout/logout.component.ts
@@ -27,8 +27,6 @@ export class LogoutComponent implements OnInit {
   private spinnerService = inject(SpinnerService)
 
   public baseHref = getBaseHrefPath()
-  protected isSubmitting = false
-
   history = window.history
 
   async ngOnInit() {
@@ -60,51 +58,6 @@ export class LogoutComponent implements OnInit {
     } else {
       this.spinnerService.show(true)
       window.location.assign(`${this.baseHref}/oidc/session/end`)
-    }
-  }
-
-  protected async onSubmit(event: SubmitEvent) {
-    event.preventDefault()
-
-    if (this.isSubmitting) return
-
-    const form = event.currentTarget
-    if (!(form instanceof HTMLFormElement)) return
-
-    const formData = new FormData(form)
-    const body = new URLSearchParams()
-    for (const [key, value] of formData.entries()) {
-      if (typeof value === 'string') {
-        body.append(key, value)
-      }
-    }
-
-    try {
-      this.isSubmitting = true
-      this.spinnerService.show(true)
-
-      const response = await fetch(form.action, {
-        method: 'POST',
-        body: body.toString(),
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-        },
-        credentials: 'include',
-        redirect: 'manual',
-      })
-
-      const location = response.headers.get('location')
-      if (location) {
-        window.location.assign(location)
-        return
-      }
-
-      if (response.status >= 400) {
-        throw new Error('Logout failed. Please try again.')
-      }
-    } finally {
-      this.isSubmitting = false
-      this.spinnerService.hide()
     }
   }
 }

--- a/frontend/src/app/pages/logout/logout.component.ts
+++ b/frontend/src/app/pages/logout/logout.component.ts
@@ -27,6 +27,7 @@ export class LogoutComponent implements OnInit {
   private spinnerService = inject(SpinnerService)
 
   public baseHref = getBaseHrefPath()
+  protected isSubmitting = false
 
   history = window.history
 
@@ -59,6 +60,51 @@ export class LogoutComponent implements OnInit {
     } else {
       this.spinnerService.show(true)
       window.location.assign(`${this.baseHref}/oidc/session/end`)
+    }
+  }
+
+  protected async onSubmit(event: SubmitEvent) {
+    event.preventDefault()
+
+    if (this.isSubmitting) return
+
+    const form = event.currentTarget
+    if (!(form instanceof HTMLFormElement)) return
+
+    const formData = new FormData(form)
+    const body = new URLSearchParams()
+    for (const [key, value] of formData.entries()) {
+      if (typeof value === 'string') {
+        body.append(key, value)
+      }
+    }
+
+    try {
+      this.isSubmitting = true
+      this.spinnerService.show(true)
+
+      const response = await fetch(form.action, {
+        method: 'POST',
+        body: body.toString(),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        },
+        credentials: 'include',
+        redirect: 'manual',
+      })
+
+      const location = response.headers.get('location')
+      if (location) {
+        window.location.assign(location)
+        return
+      }
+
+      if (response.status >= 400) {
+        throw new Error('Logout failed. Please try again.')
+      }
+    } finally {
+      this.isSubmitting = false
+      this.spinnerService.hide()
     }
   }
 }

--- a/frontend/src/app/services/spinner.service.ts
+++ b/frontend/src/app/services/spinner.service.ts
@@ -8,19 +8,39 @@ export class SpinnerService {
   private ngxSpinnerService = inject(NgxSpinnerService)
 
   private count = 0
+  private showTimeout?: ReturnType<typeof setTimeout>
+  private hideTimeout?: ReturnType<typeof setTimeout>
 
   show(immediate: boolean = false) {
-    this.count++
-    setTimeout(() => {
+    this.count = this.count + 1
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout)
+      this.hideTimeout = undefined
+    }
+    if (this.showTimeout) {
+      clearTimeout(this.showTimeout)
+    }
+    this.showTimeout = setTimeout(() => {
+      this.showTimeout = undefined
       this.checkStatusShow()
     }, immediate ? 0 : 500) // Do not show the spinner if the operation is very fast
   }
 
   hide() {
-    this.count--
-    setTimeout(() => {
-      this.checkStatusHide()
-    }, 2000) // Keep the spinner visible for a bit to avoid flickering
+    this.count = Math.max(this.count - 1, 0)
+    if (this.showTimeout) {
+      clearTimeout(this.showTimeout)
+      this.showTimeout = undefined
+    }
+    if (this.count <= 0) {
+      if (this.hideTimeout) {
+        clearTimeout(this.hideTimeout)
+      }
+      this.hideTimeout = setTimeout(() => {
+        this.hideTimeout = undefined
+        this.checkStatusHide()
+      }, 2000) // Keep the spinner visible for a bit to avoid flickering
+    }
   }
 
   private checkStatusShow() {


### PR DESCRIPTION
## Summary

This patch addresses #418 by restoring native form submission for the OIDC logout confirmation page.

### Why this fixes the issue
The page was intercepting submit via JavaScript `fetch` and trying to manually handle redirects. That can prevent browsers from following the 303 response from `POST /oidc/session/end/confirm` as expected.

- Removed the custom `(submit)` handler on the logout confirmation form.
- Removed the JS-based `onSubmit` POST logic.
- Kept the existing flow of a server-driven `POST /oidc/session/end/confirm` form target.

### Verification
- Built the frontend (`npm run -C frontend build:dev`) successfully after the change.

This keeps behavior aligned with the intended flow: after confirmation, the browser naturally follows the provider’s redirect response.
