### PR TITLE
Add support for docker secrets via FILE__ variables

### DIFF
--- a/server/util/config.ts
+++ b/server/util/config.ts
@@ -1,4 +1,5 @@
 import { exit } from 'node:process'
+import { readFile } from 'node:fs/promises'
 import { booleanString } from './util'
 import { logger } from './logger'
 import * as psl from 'psl'
@@ -404,10 +405,30 @@ function stringDuration(durationStr: unknown) {
 
 const configKeys = Object.getOwnPropertyNames(appConfig) as (keyof Config)[]
 
-// read from process env vars
-configKeys.forEach((key: keyof Config) => {
-  assignConfigValue(key, process.env[key])
-})
+// read from process env vars or the given FILE__
+for (const key of configKeys) {
+  const envValue = process.env[key]
+  const fileEnvKey = `FILE__${key}`
+  const fileEnvKeyValue = process.env[fileEnvKey]
+  const fileValue = fileEnvKeyValue !== undefined
+    ? (await readFile(fileEnvKeyValue, 'utf8')
+        .catch((err: unknown) => {
+          if ((<{ code: unknown }>err).code !== 'ENOENT') {
+            throw err
+          }
+        })
+      )?.trim()
+    : undefined
+  if (envValue && fileValue) {
+    logger({
+      level: 'error',
+      message: `${key} and ${fileEnvKey} cannot both be set.`,
+    })
+    exit(1)
+  }
+  const value = envValue ?? fileValue
+  assignConfigValue(key, value)
+}
 
 refreshDeclaredClients(await registerDockerListener())
 


### PR DESCRIPTION
## Description
<!-- 
Required, DO NOT leave this blank!
This PR adds/removes/updates/fixes the feature/bug. 
-->

This PR adds support for docker secrets, by reading configuration options from either environment variables (the usual) or the given files (path provided via `FILE__VAR` env vars).

I did minimal changes to the `config.ts`; I manually tested it works. I'm open to suggestions on how to reword documentation or even the base compose.yml to indicate how to use secrets.

For context, something like the following works:

```sh
# Add the minimal required secrets to ./secrets
mkdir secrets
echo -n 'some_password' > secrets/db_password
echo -n 'very_long_and_longer_and_longer_storage_key' > secrets/storage_key
```

```yaml
# compose.yaml: Replace the vars by FILE__ vars and add docker secrets
services:
  voidauth: 
    image: voidauth/voidauth:latest
    restart: unless-stopped
    volumes:
      - ./voidauth/config:/app/config
      # Only required for declaring OIDC Apps via docker labels (see OIDC-Setup documentation)
      # - /var/run/docker.sock:/var/run/docker.sock:ro
    ports:
      - "3000:3000" # may not be needed, depending on reverse-proxy setup
      # - "3890:3890" # only needed if LDAP Server is enabled
    environment:
      # Required environment variables
      # See https://voidauth.app/#/Getting-Started?id=environment-variables for a list of possible environment variables
      APP_URL: # required
      DB_ADAPTER: postgres # this is the default value
      DB_HOST: voidauth-db # required
      FILE__DB_PASSWORD: /run/secrets/db_password
      FILE__STORAGE_KEY: /run/secrets/storage_key
    secrets:
      - db_password
      - storage_key
    depends_on:
      voidauth-db:
        condition: service_healthy

  voidauth-db:
    image: postgres:18
    restart: unless-stopped
    environment:
      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
    ports:
      # NOTE: Had to map the port to access via localhost for local development
      - 54320:5432
    volumes:
      - ./voidauth/db:/var/lib/postgresql/18/docker
    secrets:
      - db_password
    healthcheck:
      test: "pg_isready -U postgres -h localhost"

secrets:
  db_password:
    file: ./secrets/db_password
  storage_key:
    file: ./secrets/storage_key
```

```env
# For local dev:
APP_URL="http://localhost:3000"
DB_HOST="localhost"
DB_PORT=54320
FILE__STORAGE_KEY=./secrets/storage_key
FILE__DB_PASSWORD=./secrets/db_password
```

## Related Tickets & Documents
<!-- Link any issues this fixes -->

I couldn't find any recent or old issue or PR related to docker secrets. Let me know if I should open one to track this feature.

About docker secrets: https://docs.docker.com/reference/compose-file/secrets/

## AI Usage
<!-- If any AI tooling was used to generate any part of this contribution, mention the tool and in what way it was used. See details in the CONTRIBUTING.md contribution guide -->

I did not use AI to write this code.

## Screenshots

<!-- Any visual changes require screenshots -->

N/A