### PR TITLE
fix: disable default Cross-Origin-Opener-Policy header for popup OIDC flows

### DIFF
--- a/server/cli/server.ts
+++ b/server/cli/server.ts
@@ -37,6 +37,7 @@ export async function serve() {
   provider.proxy = true
 
   app.use(helmet({
+    crossOriginOpenerPolicy: false,
     contentSecurityPolicy: {
       // use safe defaults, and also...
       useDefaults: true,


### PR DESCRIPTION
## Description
<!-- 
Required, DO NOT leave this blank!
This PR adds/removes/updates/fixes the feature/bug. 
-->

Disable the `Cross-Origin-Opener-Policy: same-origin` header that gets set by default by `Helmet`. The policy places cross-origin popup pages in a separate browsing-context, which means `window.opener` is `null`. Some OIDC clients rely on the opener to complete the login handoff. I saw this cause problems with Synology DSM [and with Komga](https://github.com/gotson/komga/discussions/2328).

~~I also added a backend test and npm script to run it. Let me know if you don't want this.~~

## Related Tickets & Documents
<!-- Link any issues this fixes -->
None

## AI Usage
<!-- If any AI tooling was used to generate any part of this contribution, mention the tool and in what way it was used. See details in the CONTRIBUTING.md contribution guide -->
~~I used Codex with gpt-5.6 to write the regression test.~~

## Screenshots
N/A
