### PR TITLE
Store Current Table Page Size and API Pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Documentation, especially app setup guides, are largely community driven and so 
 
 ### Features and Fixes
 
-Please read the CONTRIBUTING.md to see setup guide. Collaboration in an issue or discussion before opening a Pull Request will improve chances of merging, but is not required.
+Please read the CONTRIBUTING.md to see setup guide. Collaboration in an issue or discussion before opening a Pull Request will improve chances of changes being accepted, but is not required.
 
 ## Disclaimer
 

--- a/frontend/src/app/dialogs/option-value-dialog/option-value-dialog.component.html
+++ b/frontend/src/app/dialogs/option-value-dialog/option-value-dialog.component.html
@@ -18,7 +18,7 @@
         (focus)="updateFilteredOptions(input.value)"
       />
       <mat-autocomplete #optionAuto="matAutocomplete" [requireSelection]="!data.allowNew">
-        @for (option of filteredOptions; track option) {
+        @for (option of filteredOptions(); track option) {
           <mat-option [value]="option">{{ option }}</mat-option>
         }
       </mat-autocomplete>

--- a/frontend/src/app/dialogs/option-value-dialog/option-value-dialog.component.ts
+++ b/frontend/src/app/dialogs/option-value-dialog/option-value-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, type OnInit } from '@angular/core'
+import { Component, inject, signal, type OnInit } from '@angular/core'
 import { AbstractControl, FormControl, FormGroup, ReactiveFormsModule, Validators, type ValidatorFn } from '@angular/forms'
 import { MAT_DIALOG_DATA } from '@angular/material/dialog'
 import { MaterialModule } from '../../material-module'
@@ -12,10 +12,12 @@ export type OptionValueDialogData = {
   newForbidden?: string[]
   header?: string
   optionLabel?: string
-  availableOptions: string[]
   currentOption?: string
   currentValue?: string
-}
+} & (
+  { availableOptions: string[], fetchOptions?: undefined }
+  | { availableOptions?: undefined, fetchOptions: (searchTerm: string) => Promise<string[]> }
+)
 
 export type OptionValueResult = {
   option: string
@@ -37,7 +39,7 @@ export type OptionValueResult = {
 export class OptionValueDialogComponent implements OnInit {
   readonly data = inject<OptionValueDialogData>(MAT_DIALOG_DATA)
 
-  public filteredOptions: string[] = []
+  public filteredOptions = signal<string[]>([])
 
   readonly form = new FormGroup({
     option: new FormControl<string | null>(null, [
@@ -60,12 +62,14 @@ export class OptionValueDialogComponent implements OnInit {
     return this.form.controls.value
   }
 
-  ngOnInit(): void {
+  async ngOnInit(): Promise<void> {
     if (this.data.currentOption) {
       this.option.setValue(this.data.currentOption)
       this.value.setValue(this.data.currentValue ?? null)
       this.option.disable({ emitEvent: false })
     }
+
+    await this.updateFilteredOptions(null)
   }
 
   get optionValue() {
@@ -73,14 +77,19 @@ export class OptionValueDialogComponent implements OnInit {
     return raw.option && raw.value ? raw : null
   }
 
-  public updateFilteredOptions(value: string | null) {
-    const filterValue = value?.trim().toLowerCase() ?? ''
-    let options = this.data.availableOptions
-    if (filterValue) {
-      options = options.filter(option => option.toLowerCase().includes(filterValue))
-    }
+  public async updateFilteredOptions(value: string | null) {
+    const filterValue = value?.trim() ?? ''
 
-    this.filteredOptions = options.slice(0, 5)
+    if (this.data.fetchOptions) {
+      this.filteredOptions.set(await this.data.fetchOptions(filterValue))
+    } else {
+      let options = this.data.availableOptions
+      if (filterValue) {
+        options = options.filter(option => option.toLowerCase().includes(filterValue.toLowerCase()))
+      }
+
+      this.filteredOptions.set(options.slice(0, 5))
+    }
   }
 
   private forbiddenOptionValidator(): ValidatorFn {

--- a/frontend/src/app/pages/admin/clients/clients.component.html
+++ b/frontend/src/app/pages/admin/clients/clients.component.html
@@ -51,5 +51,5 @@
 
   <div style="flex-grow: 1"></div>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="10"></mat-paginator>
+  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="tableService.currentPageSize"></mat-paginator>
 </div>

--- a/frontend/src/app/pages/admin/clients/clients.component.ts
+++ b/frontend/src/app/pages/admin/clients/clients.component.ts
@@ -13,6 +13,7 @@ import { ConfirmComponent } from '../../../dialogs/confirm/confirm.component'
 import type { ClientResponse } from '@shared/api-response/ClientResponse'
 import { TranslatePipe } from '@ngx-translate/core'
 import type { Observable } from 'rxjs'
+import { TableService } from '../../../services/table.service'
 
 export type TableColumn<T> = {
   columnDef: keyof T & string
@@ -58,11 +59,19 @@ export class ClientsComponent implements AfterViewInit {
   private snackbarService = inject(SnackbarService)
   private spinnerService = inject(SpinnerService)
   private dialog = inject(MatDialog)
+  readonly tableService = inject(TableService)
 
   async ngAfterViewInit() {
     try {
       // Assign the data to the data source for the table to render
       this.spinnerService.show()
+      const currentPageSize = this.tableService.currentPageSize
+      if (currentPageSize !== null) {
+        this.paginator().pageSize = currentPageSize
+      }
+      this.paginator().page.subscribe((event) => {
+        this.tableService.currentPageSize = event.pageSize
+      })
       this.dataSource.data = await this.adminService.clients()
       this.dataSource.paginator = this.paginator()
       this.dataSource.sort = this.sort()

--- a/frontend/src/app/pages/admin/custom-claims/custom-claim/custom-claim.component.ts
+++ b/frontend/src/app/pages/admin/custom-claims/custom-claim/custom-claim.component.ts
@@ -69,26 +69,30 @@ export class CustomClaimComponent implements OnInit {
     })
   }
 
-  async addUserClaim() {
-    const availableUsers = (await this.adminService.users())
-      .filter(u => !this.form.controls.users.value.some(ccu => ccu.username === u.username))
+  addUserClaim() {
+    const fetchUserOptions = async (searchTerm: string) => {
+      return (await this.adminService.users(0, 10, searchTerm)).users
+        .filter(u => !this.form.controls.users.value.some(ccu => ccu.username === u.username))
+        .map(u => u.username).slice(0, 5)
+    }
 
     const dialogRef = this.dialog.open(OptionValueDialogComponent, {
       data: {
         header: 'Add User Claim',
-        availableOptions: availableUsers.map(u => u.username),
+        fetchOptions: fetchUserOptions,
         allowNew: false,
         optionLabel: 'User',
       } satisfies OptionValueDialogData,
       disableClose: true,
     })
 
-    dialogRef.afterClosed().subscribe((result: OptionValueResult) => {
+    dialogRef.afterClosed().subscribe(async (result: OptionValueResult) => {
       if (!result) {
         return
       }
 
-      const selectedUser = availableUsers.find(u => u.username === result.option)
+      const matchingUsers = (await this.adminService.users(0, 5, result.option)).users
+      const selectedUser = matchingUsers.find(u => u.username === result.option)
 
       if (!selectedUser) {
         return
@@ -104,14 +108,17 @@ export class CustomClaimComponent implements OnInit {
     })
   }
 
-  async editUserClaim(userToEdit: ItemIn<CustomClaimDetails['users']>) {
-    const availableUsers = (await this.adminService.users())
-      .filter(u => !this.form.controls.users.value.some(ccu => ccu.username === u.username))
+  editUserClaim(userToEdit: ItemIn<CustomClaimDetails['users']>) {
+    const fetchUserOptions = async (searchTerm: string) => {
+      return (await this.adminService.users(0, 5, searchTerm)).users
+        .filter(u => !this.form.controls.users.value.some(ccu => ccu.username === u.username))
+        .map(u => u.username)
+    }
 
     const dialogRef = this.dialog.open(OptionValueDialogComponent, {
       data: {
         header: 'Edit User Claim',
-        availableOptions: availableUsers.map(u => u.username),
+        fetchOptions: fetchUserOptions,
         allowNew: false,
         optionLabel: 'User',
         currentOption: userToEdit.username,

--- a/frontend/src/app/pages/admin/custom-claims/custom-claims.component.html
+++ b/frontend/src/app/pages/admin/custom-claims/custom-claims.component.html
@@ -44,5 +44,5 @@
 
   <div style="flex-grow: 1"></div>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="10"></mat-paginator>
+  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="tableService.currentPageSize"></mat-paginator>
 </div>

--- a/frontend/src/app/pages/admin/custom-claims/custom-claims.component.ts
+++ b/frontend/src/app/pages/admin/custom-claims/custom-claims.component.ts
@@ -12,6 +12,7 @@ import type { TableColumn } from '../clients/clients.component'
 import { TranslatePipe } from '@ngx-translate/core'
 import { RouterLink } from '@angular/router'
 import type { CustomClaim } from '@shared/db/CustomClaim'
+import { TableService } from '../../../services/table.service'
 
 @Component({
   selector: 'app-custom-claims',
@@ -43,11 +44,19 @@ export class CustomClaimsComponent {
   private snackbarService = inject(SnackbarService)
   private spinnerService = inject(SpinnerService)
   private dialog = inject(MatDialog)
+  readonly tableService = inject(TableService)
 
   async ngAfterViewInit() {
     // Assign the data to the data source for the table to render
     try {
       this.spinnerService.show()
+      const currentPageSize = this.tableService.currentPageSize
+      if (currentPageSize !== null) {
+        this.paginator().pageSize = currentPageSize
+      }
+      this.paginator().page.subscribe((event) => {
+        this.tableService.currentPageSize = event.pageSize
+      })
       this.dataSource.data = await this.adminService.customClaims()
       this.dataSource.paginator = this.paginator()
       this.dataSource.sort = this.sort()

--- a/frontend/src/app/pages/admin/domains/domains.component.html
+++ b/frontend/src/app/pages/admin/domains/domains.component.html
@@ -44,5 +44,5 @@
 
   <div style="flex-grow: 1"></div>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="10"></mat-paginator>
+  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="tableService.currentPageSize"></mat-paginator>
 </div>

--- a/frontend/src/app/pages/admin/domains/domains.component.ts
+++ b/frontend/src/app/pages/admin/domains/domains.component.ts
@@ -14,6 +14,7 @@ import { MatDialog } from '@angular/material/dialog'
 import { ConfirmComponent } from '../../../dialogs/confirm/confirm.component'
 import { TranslatePipe } from '@ngx-translate/core'
 import { stringCompare } from '@shared/utils'
+import { TableService } from '../../../services/table.service'
 
 @Component({
   selector: 'app-domains',
@@ -46,11 +47,19 @@ export class DomainsComponent {
   private snackbarService = inject(SnackbarService)
   private spinnerService = inject(SpinnerService)
   private dialog = inject(MatDialog)
+  readonly tableService = inject(TableService)
 
   async ngAfterViewInit() {
     try {
       // Assign the data to the data source for the table to render
       this.spinnerService.show()
+      const currentPageSize = this.tableService.currentPageSize
+      if (currentPageSize !== null) {
+        this.paginator().pageSize = currentPageSize
+      }
+      this.paginator().page.subscribe((event) => {
+        this.tableService.currentPageSize = event.pageSize
+      })
       this.dataSource.data = await this.adminService.proxyAuths()
       this.dataSource.paginator = this.paginator()
     } finally {

--- a/frontend/src/app/pages/admin/emails/emails.component.html
+++ b/frontend/src/app/pages/admin/emails/emails.component.html
@@ -51,5 +51,5 @@
 
   <div style="flex-grow: 1"></div>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="10"></mat-paginator>
+  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="tableService.currentPageSize"></mat-paginator>
 </div>

--- a/frontend/src/app/pages/admin/emails/emails.component.ts
+++ b/frontend/src/app/pages/admin/emails/emails.component.ts
@@ -18,6 +18,7 @@ import type { CurrentUserDetails } from '@shared/api-response/UserDetails'
 import type { ConfigResponse } from '@shared/api-response/ConfigResponse'
 import { ConfigService } from '../../../services/config.service'
 import { TranslatePipe } from '@ngx-translate/core'
+import { TableService } from '../../../services/table.service'
 
 @Component({
   selector: 'app-emails',
@@ -58,6 +59,7 @@ export class EmailsComponent {
   private dialog = inject(MatDialog)
   private userService = inject(UserService)
   private configService = inject(ConfigService)
+  readonly tableService = inject(TableService)
 
   me?: CurrentUserDetails
   public config?: ConfigResponse
@@ -66,12 +68,17 @@ export class EmailsComponent {
     // Assign the data to the data source for the table to render
     try {
       this.spinnerService.show()
+      const currentPageSize = this.tableService.currentPageSize
+      if (currentPageSize !== null) {
+        this.paginator().pageSize = currentPageSize
+      }
 
       const [me, config, _] = await Promise.all([this.userService.getMyUser(), this.configService.getConfig(), this.setData()])
       this.me = me
       this.config = config
 
-      this.paginator().page.subscribe(async () => {
+      this.paginator().page.subscribe(async (event) => {
+        this.tableService.currentPageSize = event.pageSize
         await this.setData()
       })
 

--- a/frontend/src/app/pages/admin/groups/group/group.component.html
+++ b/frontend/src/app/pages/admin/groups/group/group.component.html
@@ -31,7 +31,7 @@
             (focus)="userAutoFilter(input.value)"
           />
           <mat-autocomplete (optionSelected)="addUser($event); input.value = ''" requireSelection #auto="matAutocomplete">
-            @for (option of selectableUsers; track option) {
+            @for (option of selectableUsers(); track option) {
               <mat-option [value]="option">{{ option.username }}</mat-option>
             }
           </mat-autocomplete>

--- a/frontend/src/app/pages/admin/groups/group/group.component.ts
+++ b/frontend/src/app/pages/admin/groups/group/group.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common'
-import { Component, inject, ChangeDetectionStrategy, type OnInit } from '@angular/core'
+import { Component, inject, ChangeDetectionStrategy, type OnInit, signal } from '@angular/core'
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms'
 import { MaterialModule } from '../../../../material-module'
 import { ValidationErrorPipe } from '../../../../pipes/ValidationErrorPipe'
@@ -32,9 +32,7 @@ export class GroupComponent implements OnInit {
 
   public id: string | null = null
 
-  public users: UserWithoutPassword[] = []
-  public unselectedUsers: UserWithoutPassword[] = []
-  public selectableUsers: UserWithoutPassword[] = []
+  public selectableUsers = signal<UserWithoutPassword[]>([])
   userSelect = new FormControl<UserWithoutPassword | null>(null)
 
   public form = new FormGroup({
@@ -73,8 +71,7 @@ export class GroupComponent implements OnInit {
           })
         }
 
-        this.users = await this.adminService.users()
-        this.userAutoFilter()
+        await this.userAutoFilter()
 
         if (this.form.controls.name.value?.toLowerCase() === ADMIN_GROUP.toLowerCase()) {
           this.form.controls.name.disable()
@@ -90,27 +87,16 @@ export class GroupComponent implements OnInit {
     })
   }
 
-  userAutoFilter(value: string = '') {
-    this.unselectedUsers = this.users.filter((u) => {
-      return !this.form.controls.users.value.find(gu => u.id === gu.id)
-    })
-    this.selectableUsers = this.unselectedUsers
-      .filter((u) => {
-        return (
-          u.username.toLowerCase().includes(value.toLowerCase())
-          || u.email?.toLowerCase().includes(value.toLowerCase())
-          || u.name?.toLowerCase().includes(value.toLowerCase())
-        )
-      })
-      .slice(0, 5)
-    if (this.unselectedUsers.length) {
-      this.userSelect.enable()
-    } else {
-      this.userSelect.disable()
-    }
+  async userAutoFilter(value: string = '') {
+    const selectedIds = new Set(this.form.controls.users.value.map(u => u.id))
+    const users = (await this.adminService.users(0, 10, value)).users.filter(u => !selectedIds.has(u.id)).slice(0, 5)
+
+    this.selectableUsers.set(users.sort((a, b) => {
+      return stringCompare(a.username, b.username)
+    }))
   }
 
-  addUser(event: MatAutocompleteSelectedEvent) {
+  async addUser(event: MatAutocompleteSelectedEvent) {
     const value = event.option.value as UserWithoutPassword | null
     if (!value) {
       return
@@ -122,13 +108,13 @@ export class GroupComponent implements OnInit {
     )
     this.form.controls.users.markAsDirty()
     this.userSelect.setValue(null)
-    this.userAutoFilter()
+    await this.userAutoFilter()
   }
 
-  removeUser(value: string) {
+  async removeUser(value: string) {
     this.form.controls.users.setValue(this.form.controls.users.value.filter(u => u.id !== value))
     this.form.controls.users.markAsDirty()
-    this.userAutoFilter()
+    await this.userAutoFilter()
   }
 
   async addCustomClaim() {

--- a/frontend/src/app/pages/admin/groups/groups.component.html
+++ b/frontend/src/app/pages/admin/groups/groups.component.html
@@ -48,5 +48,5 @@
 
   <div style="flex-grow: 1"></div>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="10"></mat-paginator>
+  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="tableService.currentPageSize"></mat-paginator>
 </div>

--- a/frontend/src/app/pages/admin/groups/groups.component.ts
+++ b/frontend/src/app/pages/admin/groups/groups.component.ts
@@ -13,6 +13,7 @@ import { SpinnerService } from '../../../services/spinner.service'
 import { MatDialog } from '@angular/material/dialog'
 import { ConfirmComponent } from '../../../dialogs/confirm/confirm.component'
 import { TranslatePipe } from '@ngx-translate/core'
+import { TableService } from '../../../services/table.service'
 
 @Component({
   selector: 'app-groups',
@@ -43,11 +44,19 @@ export class GroupsComponent {
   private snackbarService = inject(SnackbarService)
   private spinnerService = inject(SpinnerService)
   private dialog = inject(MatDialog)
+  readonly tableService = inject(TableService)
 
   async ngAfterViewInit() {
     try {
       // Assign the data to the data source for the table to render
       this.spinnerService.show()
+      const currentPageSize = this.tableService.currentPageSize
+      if (currentPageSize !== null) {
+        this.paginator().pageSize = currentPageSize
+      }
+      this.paginator().page.subscribe((event) => {
+        this.tableService.currentPageSize = event.pageSize
+      })
       this.dataSource.data = await this.adminService.groups()
       this.dataSource.paginator = this.paginator()
       this.dataSource.sort = this.sort()

--- a/frontend/src/app/pages/admin/invitations/invitations.component.html
+++ b/frontend/src/app/pages/admin/invitations/invitations.component.html
@@ -42,5 +42,5 @@
 
   <div style="flex-grow: 1"></div>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="10"></mat-paginator>
+  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="tableService.currentPageSize"></mat-paginator>
 </div>

--- a/frontend/src/app/pages/admin/invitations/invitations.component.ts
+++ b/frontend/src/app/pages/admin/invitations/invitations.component.ts
@@ -14,6 +14,7 @@ import { ConfirmComponent } from '../../../dialogs/confirm/confirm.component'
 import { TranslatePipe, TranslateService } from '@ngx-translate/core'
 import { HumanDurationPipe } from '../../../pipes/HumanDurationPipe'
 import { LooseAsyncPipe } from '../../../pipes/LooseAsyncPipe'
+import { TableService } from '../../../services/table.service'
 
 @Component({
   selector: 'app-invitations',
@@ -61,11 +62,19 @@ export class InvitationsComponent {
   private snackbarService = inject(SnackbarService)
   private spinnerService = inject(SpinnerService)
   private dialog = inject(MatDialog)
+  readonly tableService = inject(TableService)
 
   async ngAfterViewInit() {
     // Assign the data to the data source for the table to render
     try {
       this.spinnerService.show()
+      const currentPageSize = this.tableService.currentPageSize
+      if (currentPageSize !== null) {
+        this.paginator().pageSize = currentPageSize
+      }
+      this.paginator().page.subscribe((event) => {
+        this.tableService.currentPageSize = event.pageSize
+      })
       this.dataSource.data = await this.adminService.invitations()
       this.dataSource.paginator = this.paginator()
       this.dataSource.sort = this.sort()

--- a/frontend/src/app/pages/admin/password-resets/password-resets.component.html
+++ b/frontend/src/app/pages/admin/password-resets/password-resets.component.html
@@ -21,7 +21,7 @@
       <mat-icon fontSet="material-icons-round" matSuffix>add</mat-icon>
     </button>
     <mat-autocomplete requireSelection #auto="matAutocomplete" [displayWith]="displayUser">
-      @for (option of selectableUsers; track option) {
+      @for (option of selectableUsers(); track option) {
         <mat-option [value]="option">{{ option.username }}{{ option.email ? " (" + option.email + ")" : "" }}</mat-option>
       }
     </mat-autocomplete>
@@ -88,5 +88,5 @@
 
   <div style="flex-grow: 1"></div>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="10"></mat-paginator>
+  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="tableService.currentPageSize"></mat-paginator>
 </div>

--- a/frontend/src/app/pages/admin/password-resets/password-resets.component.ts
+++ b/frontend/src/app/pages/admin/password-resets/password-resets.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, viewChild, ChangeDetectionStrategy } from '@angular/core'
+import { Component, inject, viewChild, ChangeDetectionStrategy, signal } from '@angular/core'
 import { MaterialModule } from '../../../material-module'
 import { MatPaginator } from '@angular/material/paginator'
 import { MatSort } from '@angular/material/sort'
@@ -20,6 +20,7 @@ import { AsyncPipe } from '@angular/common'
 import { TranslatePipe, TranslateService } from '@ngx-translate/core'
 import { HumanDurationPipe } from '../../../pipes/HumanDurationPipe'
 import { LooseAsyncPipe } from '../../../pipes/LooseAsyncPipe'
+import { TableService } from '../../../services/table.service'
 
 @Component({
   selector: 'app-password-resets',
@@ -57,8 +58,7 @@ export class PasswordResetsComponent {
 
   displayedColumns = ([] as string[]).concat(this.columns.map(c => c.columnDef)).concat(['actions'])
 
-  users: UserWithoutPassword[] = []
-  selectableUsers: UserWithoutPassword[] = []
+  selectableUsers = signal<UserWithoutPassword[]>([])
   userSelect = new FormControl<UserWithoutPassword | null>(null)
 
   config?: ConfigResponse
@@ -69,27 +69,48 @@ export class PasswordResetsComponent {
   private configService = inject(ConfigService)
   private dialog = inject(MatDialog)
   private translateService = inject(TranslateService)
+  readonly tableService = inject(TableService)
+
   async ngAfterViewInit() {
-    // Assign the data to the data source for the table to render
     try {
       this.spinnerService.show()
+      const currentPageSize = this.tableService.currentPageSize
+      if (currentPageSize !== null) {
+        this.paginator().pageSize = currentPageSize
+      }
 
-      const [users, passwordResets, config] = await Promise.all([
-        this.adminService.users(),
-        this.adminService.passwordResets(),
+      const [config, _] = await Promise.all([
         this.configService.getConfig(),
+        this.setData(),
       ])
-
-      this.users = users.sort((a, b) => {
-        return stringCompare(a.username, b.username)
-      })
-      this.userAutoFilter()
 
       this.config = config
 
-      this.dataSource.data = passwordResets
-      this.dataSource.paginator = this.paginator()
-      this.dataSource.sort = this.sort()
+      this.paginator().page.subscribe(async (event) => {
+        this.tableService.currentPageSize = event.pageSize
+        await this.setData()
+      })
+
+      this.sort().sortChange.subscribe(async () => {
+        await this.setData()
+      })
+    } finally {
+      this.spinnerService.hide()
+    }
+  }
+
+  async setData() {
+    try {
+      this.spinnerService.show()
+      const pageIndex = this.paginator().pageIndex
+      const pageSize = this.paginator().pageSize
+      const sortActive = this.sort().active
+      const sortDirection = this.sort().direction
+      const data = await this.adminService.passwordResets(pageIndex, pageSize, sortActive, sortDirection)
+      this.dataSource.data = data.passwordResets
+      this.paginator().length = data.count
+    } catch (_e) {
+      this.snackbarService.error('Could not get password reset links.')
     } finally {
       this.spinnerService.hide()
     }
@@ -103,9 +124,9 @@ export class PasswordResetsComponent {
         throw new Error('User not selected.')
       }
 
-      const reset = await this.adminService.createPasswordReset({ userId: user.id })
-      const data = [reset].concat(this.dataSource.data)
-      this.dataSource.data = this.dataSource.sortData(data, this.sort())
+      await this.adminService.createPasswordReset({ userId: user.id })
+      this.userSelect.reset()
+      await this.setData()
       this.snackbarService.message('Password reset link was created.')
     } catch (_e) {
       this.snackbarService.error('Could not create password reset link.')
@@ -130,7 +151,7 @@ export class PasswordResetsComponent {
       try {
         this.spinnerService.show()
         await this.adminService.deletePasswordReset(id)
-        this.dataSource.data = this.dataSource.data.filter(g => g.id !== id)
+        await this.setData()
         this.snackbarService.message('Password reset link was deleted.')
       } catch (_e) {
         this.snackbarService.error('Could not delete password reset link.')
@@ -140,16 +161,10 @@ export class PasswordResetsComponent {
     })
   }
 
-  userAutoFilter(value: string = '') {
-    this.selectableUsers = this.users
-      .filter((u) => {
-        return (
-          u.username.toLowerCase().includes(value.toLowerCase())
-          || u.email?.toLowerCase().includes(value.toLowerCase())
-          || u.name?.toLowerCase().includes(value.toLowerCase())
-        )
-      })
-      .slice(0, 5)
+  async userAutoFilter(value: string = '') {
+    this.selectableUsers.set((await this.adminService.users(0, 5, value)).users.sort((a, b) => {
+      return stringCompare(a.username, b.username)
+    }))
   }
 
   displayUser(user?: UserWithoutPassword) {

--- a/frontend/src/app/pages/admin/users/users.component.html
+++ b/frontend/src/app/pages/admin/users/users.component.html
@@ -82,5 +82,5 @@
 
   <div style="flex-grow: 1"></div>
 
-  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="10"></mat-paginator>
+  <mat-paginator [pageSizeOptions]="[5, 10, 25, 100]" [pageSize]="tableService.currentPageSize"></mat-paginator>
 </div>

--- a/frontend/src/app/pages/admin/users/users.component.ts
+++ b/frontend/src/app/pages/admin/users/users.component.ts
@@ -18,6 +18,7 @@ import { debounceTime, distinctUntilChanged } from 'rxjs'
 import { TranslatePipe, TranslateService } from '@ngx-translate/core'
 import { HumanDurationPipe } from '../../../pipes/HumanDurationPipe'
 import { LooseAsyncPipe } from '../../../pipes/LooseAsyncPipe'
+import { TableService } from '../../../services/table.service'
 
 @Component({
   selector: 'app-users',
@@ -79,43 +80,61 @@ export class UsersComponent {
   private userService = inject(UserService)
   private spinnerService = inject(SpinnerService)
   readonly dialog = inject(MatDialog)
+  readonly tableService = inject(TableService)
 
   async ngAfterViewInit() {
-    // Assign the data to the data source for the table to render
     try {
       this.spinnerService.show()
+      const currentPageSize = this.tableService.currentPageSize
+      if (currentPageSize !== null) {
+        this.paginator().pageSize = currentPageSize
+      }
 
-      const [me, users] = await Promise.all([this.userService.getMyUser(), this.adminService.users()])
-      this.me = me
-      this.dataSource.data = users
-
+      this.me = await this.userService.getMyUser()
       this.dataSource.paginator = this.paginator()
       this.dataSource.sort = this.sort()
 
-      this.paginator().page.subscribe((_p) => {
+      this.paginator().page.subscribe(async (event) => {
+        this.tableService.currentPageSize = event.pageSize
         this.selected.forEach(s => (s.source.checked = false))
         this.selected = []
+        await this.setData()
       })
+
+      this.sort().sortChange.subscribe(async () => {
+        this.paginator().pageIndex = 0
+        await this.setData()
+      })
+
+      this.search.valueChanges.pipe(debounceTime(500), distinctUntilChanged()).subscribe(async (searchTerm) => {
+        this.paginator().pageIndex = 0
+        await this.setData(searchTerm ?? undefined)
+      })
+
+      await this.setData()
     } finally {
       this.spinnerService.hide()
     }
+  }
 
-    this.search.valueChanges.pipe(debounceTime(500), distinctUntilChanged()).subscribe((searchTerm) => {
+  async setData(searchTerm = this.search.value ?? undefined) {
+    try {
       this.spinnerService.show()
-      this.adminService
-        .users(searchTerm)
-        .then((users) => {
-          this.dataSource.data = users
-          this.selected.forEach(s => (s.source.checked = false))
-          this.selected = []
-        })
-        .catch((e: unknown) => {
-          console.error(e)
-        })
-        .finally(() => {
-          this.spinnerService.hide()
-        })
-    })
+      const pageIndex = this.paginator().pageIndex
+      const pageSize = this.paginator().pageSize
+      const sortActive = this.sort().active
+      const sortDirection = this.sort().direction
+      const data = await this.adminService.users(pageIndex, pageSize, searchTerm, sortActive, sortDirection)
+      this.dataSource.data = data.users
+      this.paginator().length = data.count
+      this.selected.forEach(s => (s.source.checked = false))
+      this.selected = []
+    } catch (e) {
+      console.error(e)
+      this.snackbarService.error('Could not get users.')
+    } finally {
+      this.spinnerService.hide()
+    }
   }
 
   toggleSelectEnabled() {

--- a/frontend/src/app/services/admin.service.ts
+++ b/frontend/src/app/services/admin.service.ts
@@ -5,7 +5,8 @@ import type { ClientUpsertRequest } from '@shared/api-request/admin/ClientUpsert
 import type { UserUpdate } from '@shared/api-request/admin/UserUpdate'
 import type { GroupUpsert } from '@shared/api-request/admin/GroupUpsert'
 import type { InvitationUpsert } from '@shared/api-request/admin/InvitationUpsert'
-import type { UserDetails, UserWithAdminIndicator } from '@shared/api-response/UserDetails'
+import type { UserDetails } from '@shared/api-response/UserDetails'
+import type { UsersResponse } from '@shared/api-response/admin/UsersResponse'
 import { type InvitationDetails } from '@shared/api-response/admin/InvitationDetails'
 import type { Group } from '@shared/db/Group'
 import type { Invitation } from '@shared/db/Invitation'
@@ -14,6 +15,7 @@ import type { GroupDetails } from '@shared/api-response/admin/GroupDetails'
 import type { ProxyAuthUpsert } from '@shared/api-request/admin/ProxyAuthUpsert'
 import type { ProxyAuthResponse } from '@shared/api-response/admin/ProxyAuthResponse'
 import type { PasswordResetUser } from '@shared/api-response/admin/PasswordResetUser'
+import type { PasswordResetsResponse } from '@shared/api-response/admin/PasswordResetsResponse'
 import type { PasswordResetCreate } from '@shared/api-request/admin/PasswordResetCreate'
 import type { EmailsResponse } from '@shared/api-response/admin/EmailsResponse'
 import type { SortDirection } from '@angular/material/sort'
@@ -111,8 +113,18 @@ export class AdminService {
     return firstValueFrom(this.http.delete<null>(`/api/admin/group/${id}`))
   }
 
-  async users(searchTerm?: string | null) {
-    return firstValueFrom(this.http.get<UserWithAdminIndicator[]>(`/api/admin/users${searchTerm ? '/' + searchTerm : ''}`))
+  async users(page: number, pageSize: number, searchTerm?: string | null, sortActive?: string, sortDirection?: SortDirection) {
+    let query = `?page=${String(page)}&pageSize=${String(pageSize)}`
+    if (searchTerm) {
+      query += `&searchTerm=${encodeURIComponent(searchTerm)}`
+    }
+    if (sortActive) {
+      query += `&sortActive=${sortActive}`
+      if (sortDirection) {
+        query += `&sortDirection=${sortDirection}`
+      }
+    }
+    return firstValueFrom(this.http.get<UsersResponse>(`/api/admin/users${query}`))
   }
 
   async user(id: string) {
@@ -159,8 +171,15 @@ export class AdminService {
     return firstValueFrom(this.http.post<null>(`/api/admin/send_invitation/${id}`, null))
   }
 
-  async passwordResets() {
-    return firstValueFrom(this.http.get<PasswordResetUser[]>('/api/admin/passwordresets'))
+  async passwordResets(page: number, pageSize: number, sortActive?: string, sortDirection?: SortDirection) {
+    let query = `?page=${String(page)}&pageSize=${String(pageSize)}`
+    if (sortActive) {
+      query += `&sortActive=${sortActive}`
+      if (sortDirection) {
+        query += `&sortDirection=${sortDirection}`
+      }
+    }
+    return firstValueFrom(this.http.get<PasswordResetsResponse>(`/api/admin/passwordresets${query}`))
   }
 
   async createPasswordReset(passwordReset: PasswordResetCreate) {

--- a/frontend/src/app/services/table.service.ts
+++ b/frontend/src/app/services/table.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@angular/core'
+
+const MIN_PAGE_SIZE = 10
+const MAX_PAGE_SIZE = 1000
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TableService {
+  private readonly storageKey = 'voidauth-current-page-size'
+  private _currentPageSize: number | null = null
+
+  constructor() {
+    this._currentPageSize = this.getCurrentPageSize()
+  }
+
+  get currentPageSize(): number | null {
+    return this._currentPageSize
+  }
+
+  set currentPageSize(pageSize: number | null) {
+    this.setCurrentPageSize(pageSize)
+  }
+
+  private getCurrentPageSize(): number | null {
+    const localStorageValue = localStorage.getItem(this.storageKey)
+
+    if (!localStorageValue) {
+      return null
+    }
+
+    const storedPageSize = this.normalizePageSize(Number.parseInt(localStorageValue, 10))
+    return storedPageSize
+  }
+
+  private setCurrentPageSize(pageSize: number | null): void {
+    if (pageSize === null) {
+      this._currentPageSize = null
+      localStorage.removeItem(this.storageKey)
+      return
+    }
+
+    const normalizedPageSize = this.normalizePageSize(pageSize)
+    this._currentPageSize = normalizedPageSize
+    localStorage.setItem(this.storageKey, String(normalizedPageSize))
+  }
+
+  private normalizePageSize(pageSize: number): number | null {
+    if (!Number.isFinite(pageSize)) {
+      return null
+    }
+
+    if (pageSize < MIN_PAGE_SIZE) {
+      return MIN_PAGE_SIZE
+    }
+
+    if (pageSize > MAX_PAGE_SIZE) {
+      return MAX_PAGE_SIZE
+    }
+
+    return pageSize
+  }
+}

--- a/server/db/user.ts
+++ b/server/db/user.ts
@@ -1,7 +1,7 @@
 import type { Account, AccountClaims, KoaContextWithOIDC } from 'oidc-provider'
 import { db } from './db'
 import type { UserGroup, Group } from '@shared/db/Group'
-import type { UserDetails, UserWithAdminIndicator } from '@shared/api-response/UserDetails'
+import type { UserDetails } from '@shared/api-response/UserDetails'
 import type { User } from '@shared/db/User'
 import { ADMIN_USER, ADMIN_GROUP, TTLs } from '@shared/constants'
 import { randomBytes, randomUUID } from 'crypto'
@@ -17,9 +17,20 @@ import { getEnglishDuration } from '@shared/utils'
 import { TABLES } from '@shared/db'
 import { getGroupsCustomClaims, getUserCustomClaims } from './claims'
 import { calculateCustomClaims } from '@shared/user'
+import type { UsersResponse } from '@shared/api-response/admin/UsersResponse'
 
-export async function getUsers(searchTerm?: string): Promise<UserWithAdminIndicator[]> {
-  return (await db().table<User>(TABLES.USER).select<(User & { isAdmin: number })[]>('user.*', db().raw(`
+export async function getUsers(
+  options: {
+    page: number
+    pageSize: number
+    searchTerm?: string
+    sortActive?: 'username' | 'email' | 'emailVerified' | 'approved' | 'expiresAt' | 'createdAt'
+    sortDirection?: 'asc' | 'desc' | ''
+  },
+): Promise<UsersResponse> {
+  const { page, pageSize, searchTerm, sortActive = 'createdAt', sortDirection = 'desc' } = options
+
+  const query = db().table<User>(TABLES.USER).select<(User & { isAdmin: number })[]>('user.*', db().raw(`
       CASE 
         WHEN EXISTS (
           SELECT 1 
@@ -34,8 +45,34 @@ export async function getUsers(searchTerm?: string): Promise<UserWithAdminIndica
     if (searchTerm) {
       w.whereRaw('lower("username") like lower(?)', [`%${searchTerm}%`])
       w.orWhereRaw('lower("email") like lower(?)', [`%${searchTerm}%`])
+      w.orWhereRaw('lower("name") like lower(?)', [`%${searchTerm}%`])
     }
-  }).orderBy(db().ref('createdAt').withSchema(TABLES.USER), 'desc')).map((user) => {
+  })
+
+  const count = +((await query.clone().count({ count: '*' }).first())?.count ?? 0)
+
+  switch (sortActive) {
+    case 'username':
+      query.orderBy('username', sortDirection || 'asc')
+      break
+    case 'email':
+      query.orderBy('email', sortDirection || 'asc')
+      break
+    case 'emailVerified':
+      query.orderBy('emailVerified', sortDirection || 'desc')
+      break
+    case 'approved':
+      query.orderBy('approved', sortDirection || 'desc')
+      break
+    case 'expiresAt':
+      query.orderBy('expiresAt', sortDirection || 'desc')
+      break
+    case 'createdAt':
+    default:
+      query.orderBy('createdAt', sortDirection || 'desc')
+  }
+
+  const users = (await query.clone().offset(page * pageSize).limit(pageSize)).map((user) => {
     const { passwordHash, isAdmin, ...u } = user
     return {
       ...u,
@@ -44,6 +81,8 @@ export async function getUsers(searchTerm?: string): Promise<UserWithAdminIndica
       hasEmail: !!user.email,
     }
   })
+
+  return { count, users }
 }
 
 export async function getLDAPVisibleUsers(limit = 1000): Promise<Pick<User, 'id' | 'username' | 'name' | 'email'>[]> {

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -12,10 +12,10 @@ import { ADMIN_GROUP, PROTECTED_CLAIMS_SET, TTLs } from '@shared/constants'
 import { userUpdateValidator } from '@shared/api-request/admin/UserUpdate'
 import { endSessions, getUserById, getUsers } from '../db/user'
 import { createExpiration, mergeKeys } from '../db/util'
-import type { UserWithAdminIndicator } from '@shared/api-response/UserDetails'
 import { getInvitationDetails, getInvitations } from '../db/invitations'
 import type { Invitation } from '@shared/db/Invitation'
 import { invitationUpsertValidator } from '@shared/api-request/admin/InvitationUpsert'
+import type { UsersResponse } from '@shared/api-response/admin/UsersResponse'
 import { sendApproved, sendInvitation, sendPasswordReset, sendTestNotification, SMTP_VERIFIED } from '../util/email'
 import type { GroupDetails } from '@shared/api-response/admin/GroupDetails'
 import type { ProxyAuth } from '@shared/db/ProxyAuth'
@@ -24,6 +24,7 @@ import type { ProxyAuthResponse } from '@shared/api-response/admin/ProxyAuthResp
 import { proxyAuthUpsertValidator } from '@shared/api-request/admin/ProxyAuthUpsert'
 import { getProxyAuth, getProxyAuths } from '../db/proxyAuth'
 import type { PasswordResetUser } from '@shared/api-response/admin/PasswordResetUser'
+import type { PasswordResetsResponse } from '@shared/api-response/admin/PasswordResetsResponse'
 import type { PasswordReset } from '@shared/db/PasswordReset'
 import { passwordResetCreateValidator } from '@shared/api-request/admin/PasswordResetCreate'
 import type { EmailLog } from '@shared/db/EmailLog'
@@ -396,15 +397,26 @@ adminRouter.delete('/proxyauth/:id',
     res.send()
   })
 
-adminRouter.get('/users{/:searchTerm}',
+adminRouter.get('/users',
   zodValidate({
-    params: {
+    query: {
+      page: zod.coerce.number<string>().int().min(0),
+      pageSize: zod.coerce.number<string>().int().min(1),
       searchTerm: zod.string().trim().optional(),
+      sortActive: zod.enum(['username', 'email', 'emailVerified', 'approved', 'expiresAt', 'createdAt']).optional(),
+      sortDirection: zod.enum(['asc', 'desc', '']).optional(),
     },
   }), async (req, res) => {
-    const { searchTerm } = req.params
-    const users: UserWithAdminIndicator[] = await getUsers(searchTerm)
-    res.send(users)
+    const { page, pageSize, searchTerm, sortActive, sortDirection } = req.query
+
+    const result = await getUsers({
+      page,
+      pageSize,
+      searchTerm,
+      sortActive,
+      sortDirection,
+    })
+    res.send(result satisfies UsersResponse)
   })
 
 adminRouter.get('/user/:id',
@@ -1039,21 +1051,45 @@ adminRouter.post('/send_invitation/:id',
     res.send()
   })
 
-adminRouter.get('/passwordresets', async (_req, res) => {
-  const passwordResets: PasswordResetUser[] = await db().select(
-    db().ref('username').withSchema(TABLES.USER),
-    db().ref('email').withSchema(TABLES.USER),
-    db().ref('id').withSchema(TABLES.PASSWORD_RESET),
-    db().ref('userId').withSchema(TABLES.PASSWORD_RESET),
-    db().ref('challenge').withSchema(TABLES.PASSWORD_RESET),
-    db().ref('expiresAt').withSchema(TABLES.PASSWORD_RESET),
-    db().ref('createdAt').withSchema(TABLES.PASSWORD_RESET),
-  ).table<PasswordReset>(TABLES.PASSWORD_RESET)
-    .innerJoin<User>(TABLES.USER, 'user.id', 'password_reset.userId')
-    .where(db().ref('expiresAt').withSchema(TABLES.PASSWORD_RESET), '>=', new Date())
-    .orderBy(db().ref('expiresAt').withSchema(TABLES.PASSWORD_RESET), 'desc')
-  res.send(passwordResets)
-})
+adminRouter.get('/passwordresets',
+  zodValidate({
+    query: {
+      page: zod.coerce.number<string>().int().min(0),
+      pageSize: zod.coerce.number<string>().int().min(1),
+      sortActive: zod.enum(['username', 'expiresAt']).optional(),
+      sortDirection: zod.enum(['asc', 'desc', '']).optional(),
+    },
+  }), async (req, res) => {
+    const { page, pageSize, sortActive, sortDirection } = req.query
+
+    const passwordResetsModel = db().select(
+      db().ref('username').withSchema(TABLES.USER),
+      db().ref('email').withSchema(TABLES.USER),
+      db().ref('id').withSchema(TABLES.PASSWORD_RESET),
+      db().ref('userId').withSchema(TABLES.PASSWORD_RESET),
+      db().ref('challenge').withSchema(TABLES.PASSWORD_RESET),
+      db().ref('expiresAt').withSchema(TABLES.PASSWORD_RESET),
+      db().ref('createdAt').withSchema(TABLES.PASSWORD_RESET),
+    ).table<PasswordReset>(TABLES.PASSWORD_RESET)
+      .innerJoin<User>(TABLES.USER, 'user.id', 'password_reset.userId')
+      .where(db().ref('expiresAt').withSchema(TABLES.PASSWORD_RESET), '>=', new Date())
+
+    const count = +((await passwordResetsModel.clone().count({ count: '*' }).first())?.count ?? 0)
+
+    switch (sortActive) {
+      case 'username':
+        passwordResetsModel.orderBy(db().ref('username').withSchema(TABLES.USER), sortDirection || 'asc')
+        break
+      case 'expiresAt':
+      default:
+        passwordResetsModel.orderBy(db().ref('expiresAt').withSchema(TABLES.PASSWORD_RESET), sortDirection || 'desc')
+    }
+
+    const passwordResets = await passwordResetsModel.clone().offset(page * pageSize).limit(pageSize)
+    const result = { count, passwordResets }
+
+    res.send(result satisfies PasswordResetsResponse)
+  })
 
 adminRouter.post('/passwordreset',
   zodValidate({ body: passwordResetCreateValidator }), async (req, res) => {
@@ -1150,9 +1186,9 @@ adminRouter.get('/emails',
       }
     })
 
-    const result: EmailsResponse = { count, emails }
+    const result = { count, emails }
 
-    res.send(result)
+    res.send(result satisfies EmailsResponse)
   })
 
 adminRouter.post('/send_test_email',

--- a/shared/api-response/admin/PasswordResetsResponse.ts
+++ b/shared/api-response/admin/PasswordResetsResponse.ts
@@ -1,0 +1,6 @@
+import type { Paginated } from '../Paginated'
+import type { PasswordResetUser } from './PasswordResetUser'
+
+export type PasswordResetsResponse = Paginated & {
+  passwordResets: PasswordResetUser[]
+}

--- a/shared/api-response/admin/UsersResponse.ts
+++ b/shared/api-response/admin/UsersResponse.ts
@@ -1,0 +1,6 @@
+import type { UserWithAdminIndicator } from '../UserDetails'
+import type { Paginated } from '../Paginated'
+
+export type UsersResponse = Paginated & {
+  users: UserWithAdminIndicator[]
+}


### PR DESCRIPTION
## Description

* Add localStorage for currentPageSize so it can be remembered between admin pages.
* Make potentially unbound records password-resets and users (if open signups are enabled) api endpoints paginated.

## Related Tickets & Documents
#524 

